### PR TITLE
Add commentary around spec point adherence tracking (moved from `ably/features`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ _[Ably](https://ably.com) is the platform that powers synchronized digital exper
 
 This repository has been created as the new home for the 'features spec' that describes the interfaces, implementation details and behaviours of SDKs (sometimes referred to as client libraries) that provide application developers with support to integrate and leverage the Ably platform in their solutions.
 
+## Future Direction for Specification Point Adherence Tracking
+
+We have
+[this Google Sheets document](https://docs.google.com/spreadsheets/d/1ZbAfImxRLRKZNe4KPX7b_0BVVI-qyqnvbAco5TFWSQU/edit?usp=sharing)
+which has been used at Ably, by client library SDK developers,
+to indicate adherence to individual
+[feature specification points](https://sdk.ably.com/builds/ably/specification/main/features/)
+by their
+SDK source codebase.
+_Request permission from your Manager if you would like access to this spreadsheet._
+
+The detail captured in that spreadsheet is an important source of information which should be able to help us understand the level of features specification compliance across our SDKs. As such, it should be considered a valuable source of truth when it comes to working out what features are implemented across our SDKs.
+
+Additionally, it is very likely that we will continue to want to track feature specification point adherence, at that level of fine granularity, going forwards.
+
+What is clear, however, is that a Google Sheets document is probably not the appropriate venue to continue tracking this information. Instead, the currently anticipated solution is that we export the information per-SDK from that spreadsheet and represent it in a simple format as a 'feature specification point adherence checklist' (/ manifest) in each SDK source code repository (CSV, YAML or some other logical textual data format). This would be instantiated via an initial snapshot process, after which it could be evolved atomically as an additional part of the source code of that SDK, with the spreadsheet becoming obsolete once all SDKs have been exported.
+
 ## Contributing
 
 For guidance on how to contribute to this project, see [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Moved from the features repository at:
https://github.com/ably/features/blob/a9cbdd298b43fd9a63816e5cad608d3c72968b67/README.md?plain=1#L106