### PR TITLE
More stringent versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,15 @@ by adding a local development HTTP server.
 When making changes to [the spec](textile/features.textile), please follow these guidelines:
 
 - **Ordering**: Spec items should generally appear in ID order, but priority should be placed on ordering them in a way that makes coherent sense, even if that results in them being numbered out-of-order. For example, if `XXX1`, `XXX2` and `XXX3` exist but it would make more sense for `XXX3` to follow `XXX1`, then just move the spec items accordingly without changing their IDs
-- **Addition**: When adding a new spec item, choose an ID that is greater than all others that exist in the given section, even if there is a gap in the currently assigned IDs. This is desirable so that client library references to spec items are still semantically valid even after they are removed from the spec rather than now having different semantics due to the ID being re-used. For example, if `XXX1a` and `XXX1c` exist but `XXX1b` doesn’t because it was removed in the past, then introduce `XXX1d` for the new spec item rather than re-using `XXX1b`
-- **Removal**: When removing a spec item, it must remain but replace all text with “This clause has been deleted.”. See [#1057](https://github.com/ably/docs/pull/1057) for an example of this in practice.
+- **Addition**: When adding a new spec item, choose an ID that is greater than all others that exist in the given section, even if there is a gap in the currently assigned IDs. 
+- **Modification**: Spec items should never be mutated, except to patch a mistake that doesn't change the semantics for SDK implementations. Follow the guidance outlined here in respect of _Replacement_ if the meaning or scope of a spec point needs to change.
+- **Removal**: When removing a spec item, it must remain but replace all text with `This clause has been deleted as of version Y.Z of this specification`. See [#1057](https://github.com/ably/docs/pull/1057) for an example of this in practice.
+- **Replacement**: When replacing a spec item, it must remain but replace all text with `This clause has been replaced by "X":#X as of version Y.Z of this specification`.
 - **Deprecation**: Our approach to deprecating features is yet to be fully evolved and documented, however we have a current standard in place whereby the text "(deprecated)" is inserted at the beginning of a specification point to declare that it will be removed in a future release. The likely outcome is that in the next major release of the spec/protocol we'll remove that spec item, per guidance above.
+
+Historically, before the above guidance was established - in particular around _Removal_ and _Replacement_ - there have been some cases where spec points were completely deleted.
+This left us open to the problem that client library references to spec items could end up semantically invalid if that spec point was re-used later.
+For example, if `XXX1a` and `XXX1c` exist but `XXX1b` doesn’t because it was removed in the past (prior to this guidance being established), then we should introduce `XXX1d` for the new spec item rather than re-using `XXX1b`.
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ _[Ably](https://ably.com) is the platform that powers synchronized digital exper
 
 This repository has been created as the new home for the 'features spec' that describes the interfaces, implementation details and behaviours of SDKs (sometimes referred to as client libraries) that provide application developers with support to integrate and leverage the Ably platform in their solutions.
 
+## Versioning
+
+The version for all source contained within this repository as well as all artifacts generated or built from it is defined in [package.json](package.json).
+See [Release Process](CONTRIBUTING.md#release-process) for more details.
+
 ## Future Direction for Specification Point Adherence Tracking
 
 We have

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ably/specification",
-  "version": "1.2.0-alpha.1",
+  "version": "2.0.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ably/specification",
-      "version": "1.2.0-alpha.1",
+      "version": "2.0.0-alpha.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably/specification",
-  "version": "1.2.0-alpha.1",
+  "version": "2.0.0-alpha.1",
   "scripts": {
     "build": "npm-run-all build:generate build:tailwind",
     "build:generate": "./scripts/build",

--- a/textile/features.textile
+++ b/textile/features.textile
@@ -54,8 +54,13 @@ h2(#test-guidelines). Test guidelines
 * @(G1)@ Every test should be executed using all supported protocols (i.e. JSON and "MessagePack":https://msgpack.org/ if supported).  This includes both sending & receiving data
 * @(G2)@ All tests by default are run against a special Ably sandbox environment.  This environment allows apps to be provisioned without any authentication that can then be used for client library testing. Bear in mind that all apps created in the sandbox environment are automatically deleted after 60 minutes and have low limits to prevent abuse. Apps are configured by sending a @POST@ request to @https://sandbox-rest.ably.io/apps@ with a JSON body that specifies the keys and their associated capabilities, channel namespace rules and any presence fixture data that is required; see "ably-common test-app-setup.json":https://github.com/ably/ably-common/blob/main/test-resources/test-app-setup.json. Presence fixture data is necessary for the REST library presence tests as there is no way to register presence on a channel in the REST library
 * @(G3)@ Testing statistics can be tricky due to timing issues and slow test suites as a result of sending requests to generate statistics.  As such, we provide a special stats endpoint in our sandbox environment that allows stats to be injected into our metrics system so that stats tests can make predictable assertions.  To create stats you must send an authenticated @POST@ request to the stats JSON to @https://sandbox-rest.ably.io/stats@ with the stats data you wish to create. See the "JavaScript stats fixture":https://github.com/ably/ably-js/blob/4e65d4e13eb8750a375b9511e4dd059092c0e481/spec/rest/stats.test.js#L8-L51 and "setup helper":https://github.com/ably/ably-js/blob/4e65d4e13eb8750a375b9511e4dd059092c0e481/spec/common/modules/testapp_manager.js#L158-L182 as an example
-* @(G4)@ This spec defines API version 1.2. A client library must identify to Ably the version of the spec it uses in all requests and connections, per "RSC7a":#RSC7a and "RTN2f":#RTN2f. The spec it uses is defined as the latest API version for which the library implements all spec items relating to the wire protocol
-** @(G4a)@ When sending the API version to Ably, the SDK must send the exact string specified in @G4@. Therefore, it is recommended that the SDK treat the version opaquely, as a string, not a float.
+* @(G4)@ This clause has been replaced by "@G5@":#G5 as of version 2.0 of this specification
+** @(G4a)@ This clause has been replaced by "@G5c@":#G5c as of version 2.0 of this specification
+* @(G5)@ A client library must identify the version of this specification it uses in all requests and connections to the Ably service, using the mechanisms described in "@RSC7e@":#RSC7e and "@RTN2h@":#RTN2h.
+** @(G5a)@ When sending the API version to Ably, the SDK must send an exact string in the form @MAJOR.MINOR@ where the @MAJOR@ and @MINOR@ components are defined according to "SemVer":https://semver.org/ in the "the @ably/specification@ repository":https://github.com/ably/specification at the commit containg the specification source to which the SDK is conforming.
+** @(G5b)@ The SDK must only ever send the specification version in the abbreviated form specified in "@G5a@":#G5a. This means that the @PATCH@ component, as well as any pre-release or build metadata suffix, must not be included.
+** @(G5c)@ It is recommended that the SDK treat the version opaquely, as a string, not a float.
+** @(G5d)@ The version of this specification, as specified in "@G5a@":#G5a, implicitly applies to all source files managed alongside it in that source code repository. Those source files include "Ably's Realtime Websocket protocol":protocol/, also known as "the wire protocol". This means that "specification version" and "protocol version" are semantically equal, locked to one another.
 
 h2(#rest). REST client library
 
@@ -80,7 +85,7 @@ h3(#restclient). RestClient
 * @(RSC21)@ @RestClient#push@ attribute provides access to the @Push@ object that was instantiated with the @ClientOptions@ provided in the @RestClient@ constructor
 * @(RSC22)@ @RestClient#batch@ attribute provides access to the @BatchOperations@ object that was instantiated with the @ClientOptions@ provided in the @RestClient@ constructor
 * @(RSC7)@ Sends REST requests over HTTP and HTTPS to the REST endpoint @rest.ably.io@
-** @(RSC7a)@ The header @X-Ably-Version: 1.2@ must be included in all REST requests to the Ably endpoint
+** @(RSC7e)@ The HTTP header @X-Ably-Version@ must be included in all REST requests to the Ably endpoint, where the value to be sent is defined in "@G5a@":#G5a.
 ** @(RSC7b)@ (Please note this clause and the associated header have now been superseded by "RCS7d":#RSC7d) The header @X-Ably-Lib: [lib][.optional variant]?-[version]@ should be included in all REST requests to the Ably endpoint where @[lib]@ is the name of the library such as @js@ for @ably-js@, @[.optional variant]@ is an optional library variant, such as @laravel@ for the @php@ library, which is always delimited with a period such as @php.laravel@, and where @[version]@ is the full client library version using "Semver":http://semver.org/ such as @1.0.2@. For example, the 1.0.0 version of the JavaScript library would use the header @X-Ably-Lib: js-1.0.0@.
 *** @(RSC7b1)@ When it is not possible to send the @X-Ably-Lib@ header, such as for @JSONP@ requests, the library version should be sent as a query param such as @lib=js-1.0.0@
 ** @(RSC7c)@ If the @addRequestIds@ client option is enabled, every REST request to Ably should include in a @request_id@ query string parameter a random string obtained by url-safe base64-encoding a sequence of at least 9 bytes obtained from a source of randomness. This request ID must remain the same if a request is retried to a fallback host per @RSC15@. Any log messages associated with the request should include the request ID. If the request fails, the request ID must be included in the @ErrorInfo@ returned to the user.
@@ -93,6 +98,7 @@ h3(#restclient). RestClient
 *** @(RSC7d6)@ Libraries may offer a @ClientOptions#agents@ property, for use only by other Ably-authored SDKs, on a need-to-have basis.
 **** @(RSC7d6a)@ The product/version key-value pairs supplied to that property should be injected into all @Agent@ library identifiers emitted by connections made as a result of REST or Realtime instances created using those @ClientOptions@.
 **** @(RSC7d6b)@ An API commentary must be provided for this property. This commentary must make it clear that this interface is only to be used by Ably-authored SDKs.
+** @(RSC7a)@ This clause has been replaced by "@RSC7e@":#RSC7e as of version 2.0 of this specification
 * @(RSC18)@ If @ClientOptions#tls@ is true, then all communication is over HTTPS. If false, all communication is over HTTP however "Basic Auth":https://en.wikipedia.org/wiki/Basic_access_authentication over HTTP will result in an error as private keys cannot be submitted over an insecure connection. See @Auth@ below
 * @(RSC8)@ Supports two protocols:
 ** @(RSC8a)@ "MessagePack":https://msgpack.org/ binary protocol (this is the default for environments having a suitable level or support for binary data)
@@ -423,8 +429,9 @@ h3(#realtime-connection). Connection
 ** @(RTN2b)@ @echo@ should be @true@ by default; @false@ will prevent messages published by the client being echoed back
 ** @(RTN2d)@ @clientId@ contains the provided @clientId@ option of @ClientOptions@, unless @clientId@ is @null@
 ** @(RTN2e)@ Depending on the authentication scheme, either @accessToken@ contains the token string, or @key@ contains the API key
-** @(RTN2f)@ API version param @v@ should be the API version per "G4":#G4
+** @(RTN2h)@ Protocol version param @v@ must be the populated, where the value to be sent is defined in "@G5a@":#G5a
 ** @(RTN2g)@ The library and version (in the form described in "RSC7b":#RSC7b) should be included as the value of a @lib@ querystring param. For example, the 1.0.0 version of the JavaScript library would use the param @lib=js-1.0.0@
+** @(RTN2f)@ This clause has been replaced by "@RTN2h@":#RTN2h as of version 2.0 of this specification
 * @(RTN3)@ If connection option @autoConnect@ is true, a connection is initiated immediately; otherwise a connection is only initiated following an explicit call to @connect()@
 * @(RTN4)@ The @Connection@ implements @EventEmitter@ and emits @ConnectionEvent@ events, where a @ConnectionEvent@ is either a @ConnectionState@ or @UPDATE@, and a @ConnectionState@ is either @INITIALIZED@, @CONNECTING@, @CONNECTED@, @DISCONNECTED@, @SUSPENDED@, @CLOSING@, @CLOSED@, or @FAILED@
 ** @(RTN4a)@ It emits a @ConnectionState@ @ConnectionEvent@ for every connection state change


### PR DESCRIPTION
My motivation behind creating this pull request comes from an observation that came to me when reviewing #88.

I've been flying the flag for "don't mutate features spec points" for a while now, but had never written it down in so many (or is that few?) words.

In our version `1.2` spec, both `G4` and `RSC7a` had the spec version baked into them. This meant that these spec points needed to be either mutated each time the specification/protocol version was bumped (as @SimonWoolf had to do in the aforelinked PR), changing the semantic meaning of those spec points from an SDK's perspective.

The idea, going forwards, is that a spec point is all that is needed to define a particular feature or behaviour - staying constant from spec version to spec version. This means that spec points never need to carry any additional version information with them, as their meaning never changes.

This pull request aims to establish that footing more formally.