### PR TITLE
Clarify the circumstances under which RTP8f applies

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -715,7 +715,11 @@ h3(#realtime-presence). RealtimePresence
 ** @(RTP8c)@ A @PRESENCE ProtocolMessage@ with a @PresenceMessage@ with the action @ENTER@ is sent to the Ably service. The @clientId@ attribute of the @PresenceMessage@ must not be present. Entering without an explicit @PresenceMessage#clientId@, implicitly uses the @clientId@ for the current connection
 ** @(RTP8d)@ Implicitly attaches the @RealtimeChannel@ if the channel is in the @INITIALIZED@ state. However, if the channel is in the @DETACHED@ or @FAILED@ state, the @enter@ request results in an error
 ** @(RTP8e)@ Optional data and/or extras can be included when entering a channel that will be encoded and decoded as with normal messages. A test should exist to ensure data and extras used with enter are encoded & decoded correctly. Also, when data and/or extras is provided when entering, but neither data nor extras are provided when leaving, the data attribute should be emitted in the @LEAVE@ event for this client
-** @(RTP8f)@ If the client library is authenticated but unidentified (i.e. @clientId@ is a wildcard @'*'@ or client is anonymous), the @enter@ request results in an error immediately
+** @(RTP8f)@ This clause has been replaced by "RTP8j":#RTP8j as of version 1.2 of this specification
+** @(RTP8j)@ If the connection is in the @CONNECTED@ state, and the value of @RealtimeClient#clientId@ is one of the following:
+- @'*'@ – a wildcard value indicating that this client is permitted to associate any client identifier it wishes with the operations it performs;
+- @null@ – indicating that the client is anonymous and is not permitted to associate a client identifier with the operations it performs;
+then the @enter@ request results in an error immediately.
 ** @(RTP8g)@ If the channel is @DETACHED@ or @FAILED@, the @enter@ request results in an error immediately
 ** @(RTP8h)@ If the Ably service determines that the client does not have required presence permission, a @NACK@ is sent to the client resulting in an error
 ** @(RTP8i)@ If the Ably service determines that the client is unidentified, a @NACK@ is sent to the client resulting in an error


### PR DESCRIPTION
This seeks to clarify a behaviour that differs in implementation between at least two of our SDKs.

In ably-cocoa, it’s currently interpreted as meaning that [if Auth#clientId is null then RealtimePresence#enter should immediately fail](https://github.com/ably/ably-cocoa/blob/d5741ce8d3bbce0cfda7e91ff5dccc3004f81eb0/Source/ARTRealtimePresence.m#L503).

In ably-java, [this logic only applies if the client _is connected to the Ably service_](https://github.com/ably/ably-java/blob/2775178075de882d6184b3ad46a8fa2707ec48f5/lib/src/main/java/io/ably/lib/rest/Auth.java#L1263).

I think that the existing wording of RTP8f makes sense if you consider it to only apply at the point at which the client library is about to publish the `ENTER` PresenceMessage message to Ably, since RTP16b dictates that at that point the channel is `ATTACHED`, and hence the connection is `CONNECTED`, and hence (by RSA12a and RSA7b3) `Auth#clientId` contains the `clientId` from the `CONNECTED` `ProtocolMessage` received from Ably, which is authoritative information on which client ID is being used for the connection. I believe that before this point, the client library does not necessarily have authoritative information on which client ID is being used for the connection, since [Paddy describes](https://github.com/ably/ably-cocoa/issues/1126#issuecomment-855217050) RSA7b3 as being for the case where

> the client is provided with a token, which is implicitly bound to a `clientId`, but the token itself is opaque to the library; the library first learns about the `clientId` after having connected

(I do not have enough knowledge to understand the circumstances under which this “opaque to the library” situation might occur, so I’ll defer to Paddy’s word that it’s possible.)

I think that RTP8f was intended as an optimisation – that is, that it should occur only if the library can guarantee – by finding an authoritative local source of information about which client ID the connection is using, and showing that client ID to be a wildcard or null – that an attempt to enter presence would be rejected by the Ably service anyway (as described by RTP8h). I do not believe that it was intended to introduce new error scenarios.

But, if we instead consider the wording of RTP8f to apply at the point at which `RealtimePresence#enter` is called (which the word “immediately” probably means we should), then it does introduce a new error scenario, since the library might at that point not have authoritative information about which client ID the connection is using, and hence might reject a presence message that would have otherwise been accepted by the Ably service.

So, of the implementations listed above, the Java one makes more sense to me since it does not introduce a new error scenario, and I’ve updated the wording of RTP8f to reflect this behaviour, and to remove the undefined adjective “authorised” (which perhaps in the mind of the person who originally wrote this spec point made the intended behaviour clearer than it is to me).

I’ve deliberately limited the new wording to the circumstances in which the client is `CONNECTED`. I believe there are certain circumstances in which we could authoritatively state which client ID the connection will use before the client is even connected (for example, if the `ClientOptions` use a `key` and don’t specify a `clientId`), but that part of the spec seems quite complicated and I don’t want to go down that rabbit hole for what, as I said, seems to me to be an optimisation.