### PR TITLE
Require agents specified by `ClientOptions#agents` to have a version

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -91,6 +91,7 @@ h3(#restclient). RestClient
 *** @(RSC7d4)@ Where possible, product versions should be represented as a valid "semantic version":https://semver.org/. This is best-effort as we recognise that strict SemVer is not always available, or otherwise possible to derive from information available at runtime, especially in the case of products that represent operating system versions.
 *** @(RSC7d5)@ Products must be added to the canonical @agents@ data file in our common repository. See "Agents in ably-common":https://github.com/ably/ably-common/tree/main/protocol#agents for more information.
 *** @(RSC7d6)@ Libraries may offer a @ClientOptions#agents@ property, for use only by other Ably-authored SDKs, on a need-to-have basis.
+**** @(RSC7d6c)@ The type of this property is an optional dictionary with non-optional string keys and values, mapping an agent’s name to its version. This implies that all agents specified using this property must have a version.
 **** @(RSC7d6a)@ The product/version key-value pairs supplied to that property should be injected into all @Agent@ library identifiers emitted by connections made as a result of REST or Realtime instances created using those @ClientOptions@.
 **** @(RSC7d6b)@ An API commentary must be provided for this property. This commentary must make it clear that this interface is only to be used by Ably-authored SDKs.
 * @(RSC18)@ If @ClientOptions#tls@ is true, then all communication is over HTTPS. If false, all communication is over HTTP however "Basic Auth":https://en.wikipedia.org/wiki/Basic_access_authentication over HTTP will result in an error as private keys cannot be submitted over an insecure connection. See @Auth@ below
@@ -1776,7 +1777,7 @@ class ClientOptions: // TO*
   fallbackRetryTimeout: Duration default 600s // TO3l10
   plugins: Dict<PluginType, Plugin> // TO3o
   idempotentRestPublishing: bool default true // RSL1k1, RTL6a1, TO3n
-  agents: [String: String?]? // RSC7d6 - interface only offered by some libraries
+  agents: [String: String]? // RSC7d6 - interface only offered by some libraries
 
 class AuthOptions: // AO*
   authCallback: ((TokenParams) -> io (String | TokenDetails | TokenRequest | JsonObject))? // RSA4a, RSA4, TO3j5, AO2b


### PR DESCRIPTION
This comes from [a conversation I had with Quintin](https://github.com/ably/ably-cocoa/issues/1525#issuecomment-1311449934) about trying to figure out the best way to represent “this agent has no version” in Objective-C, where a dictionary cannot contain a nil value.

He suggested that it would be best to simply remove this scenario by requiring a version, since the `#agents` property is only for use by other Ably SDKs (as already made explicit by [RSC7d6b](https://sdk.ably.com/builds/ably/specification/main/features/#RSC7d6b)), which will always have a version.