### PR TITLE
Format description lists

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -85,7 +85,7 @@ plain_file_names = source_file_names.collect {
 
 source_file_names.each do |file_name|
   textile = remove_frontmatter(File.read(File.join(SOURCE_PATH, file_name)))
-  bodyHtml = RedCloth.new(textile).to_html(*REDCLOTH_RULES)
+  bodyHtml = RedCloth.new(textile, [:no_span_caps]).to_html(*REDCLOTH_RULES)
   plain_file_name = file_name.delete_suffix(SOURCE_EXTENSION)
   is_root = (plain_file_name == ROOT_SOURCE_NAME)
   html = template.call({

--- a/templates/main.css
+++ b/templates/main.css
@@ -21,6 +21,12 @@
   li {
     @apply my-1;
   }
+  dl {
+    @apply mt-1.5 mb-3;
+  }
+  dd {
+    @apply ml-10;
+  }
   code {
     @apply text-slate-600 bg-amber-100;
   }


### PR DESCRIPTION
This is a minor tweak to make [the protocol documentation](https://sdk.ably.com/builds/ably/specification/pull/114/protocol/) easier to read.

While I was there I noticed that RedCloth was superfluously adding `span` elements with a `"caps"` CSS class around three or more capital letters, so I've also removed that feature in https://github.com/ably/specification/commit/8db336ab66ad1c66be723b3963ef63749be36dd6.