### PR TITLE
Sort the index

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -76,7 +76,7 @@ template = handlebars.compile(File.read(TEMPLATE_PATH))
 
 source_file_names = Dir.children(SOURCE_PATH).select {
   |file_name| file_name.end_with? "#{SOURCE_EXTENSION}"
-}
+}.sort
 
 # File names without '.textile' extension, and without the root 'index'.
 plain_file_names = source_file_names.collect {


### PR DESCRIPTION
Because the source file name 'natural' order from the file system was varying from build to build, it was difficult as a user to use muscle memory to find items quickly from the top menu bar. Also, regardless, alphabetical sort makes more sense anyway!

**This change takes us from something like this (it varies!):**

<img width="931" alt="Screenshot 2022-11-17 at 08 28 35" src="https://user-images.githubusercontent.com/8318344/202395253-662f014a-a1ad-429e-bad7-1819468c1198.png">

**To this, consistently:**

<img width="931" alt="Screenshot 2022-11-17 at 08 27 38" src="https://user-images.githubusercontent.com/8318344/202395220-71721ddd-8679-4f87-9c2a-2ccba10f2c46.png">
