### PR TITLE
Format IDL by presenting it within an HTML `pre` element

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -1687,8 +1687,7 @@ Please note the following conventions:
 
 Each type, method, and attribute is labelled with the name of one or more clauses from the preceding feature spec. An asterisk is used as a wildcard to mean all clauses with a given prefix.
 
-```
-class RestClient: // RSC*
+pre.. class RestClient: // RSC*
   constructor(keyOrTokenStr: String) // RSC1
   constructor(ClientOptions) // RSC1
   auth: Auth // RSC5
@@ -2348,8 +2347,6 @@ class DeltaExtras // DE*
 class ReferenceExtras: // REX*
   timeserial: String // REX2a
   type: String //REX2b
-
-```
 
 h2(#old-specs). Old specs
 


### PR DESCRIPTION
We only had one location in the textile documents [moved over](https://github.com/ably/specification/blob/main/textile/notes-in-relation-to-move-from-ably-docs.md) from the original `ably/docs` home that this needed fixing in, being the IDL within our features spec.. There was no need for '[Block code](https://textile-lang.com/doc/block-code)' (`code` elements _within_ outer `pre` element) so I've kept it simple and replaced with just [Pre-formatted text](https://textile-lang.com/doc/pre-formatted-text).

When `features.textile` was rendered by the tooling in the docs repository then this backtick-fenced block was passing through [this filter](https://github.com/ably/docs/blob/65da30b98f3175e6d07d9f320d7f49ce758d57ef/lib/ably_pre_textile_filter.rb#L119), which is very clever but completely over the top for what we need in this repository context. Let's, instead, just use basic textile functionality - which is what the change in this pull request does.

Closes #11.