### PR TITLE
Replace amber background with slate for `code` elements

### DIFF
--- a/templates/main.css
+++ b/templates/main.css
@@ -28,13 +28,13 @@
     @apply ml-10;
   }
   code {
-    @apply text-slate-600 bg-amber-100;
+    @apply px-1 bg-slate-100;
   }
   pre {
     @apply my-4 p-2 border border-slate-600 bg-slate-100;
   }
   a code {
-    @apply bg-inherit hover:text-amber-700 hover:font-semibold;
+    @apply bg-inherit px-0 hover:text-amber-700 hover:font-semibold;
   }
   a {
     @apply hover:underline hover:text-amber-700;


### PR DESCRIPTION
A follow up to the work done in #116.

**This change takes us from this:**

<img width="789" alt="Screenshot 2022-11-17 at 15 37 15" src="https://user-images.githubusercontent.com/8318344/202490368-4a8c7a24-b99c-4de3-ae7e-9b16a7f609e0.png">

**to this:**

<img width="790" alt="Screenshot 2022-11-17 at 15 37 29" src="https://user-images.githubusercontent.com/8318344/202490403-f7a04074-6622-48de-ba65-75f29747a9df.png">

Which should hopefully also look nicer for those running their OS or browser in dark mode.