### PR TITLE
Resurface `RTP17c` sub clauses

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -718,6 +718,8 @@ h3(#realtime-presence). RealtimePresence
 ** @(RTP17f)@ The RealtimePresence object should perform automatic re-entry whenever a channel moves into the @ATTACHED@ state. (It does not need to do so for @RTL12@ @ATTACHED@ events received on already-@ATTACHED@ channels).
 ** @(RTP17g)@ Automatic re-entry consists of, for each member of the @RTP17@ internal @PresenceMap@, publishing a @PresenceMessage@ with an @ENTER@ action using the @clientId@, @data@, and @id@ attributes from that member.
 ** @(RTP17c)@ This clause has been replaced by "@RTP17f@":#RTP17f. It was valid up to and including specification version @1.2@.
+*** @(RTP17c1)@ This clause has been deleted. It was valid up to and including specification version @1.2@.
+*** @(RTP17c2)@ This clause has been deleted. It was valid up to and including specification version @1.2@.
 ** @(RTP17d)@ This clause has been replaced by "@RTP17g@":#RTP17g. It was valid up to and including specification version @1.2@.
 ** @(RTP17e)@ If the publish attempt fails for an automatic presence @ENTER@ (for example, by Ably rejecting it with a @NACK@), an @UPDATE@ event should be emitted on the channel with @resumed@ set to true and @reason@ set to an @ErrorInfo@ object with @code@ @91004@, a @message@ indicating that an automatic re-enter has failed and indicating the @clientId@, and @cause@ set to the reason for the enter failure. The error should also be logged at @warn@ level or higher.
 * @(RTP4)@ Ensure a test exists that enters 250 members using @RealtimePresence#enterClient@ on a single connection, and checks for @PRESENT@ events to be emitted on another connection for each member, and once sync is complete, all 250 members should be present in a @RealtimePresence#get@ request


### PR DESCRIPTION
House keeping on our protocol version 2 integration branch, in light of guidance refinements in #120 around features spec clause removal.

Fixes #122.