### PR TITLE
Trigger the assemble workflow for Git tags that look like versions

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
 
 jobs:
   build:


### PR DESCRIPTION
Surfaces the static and moveable Git tags described in #125 as builds at `sdk.ably.com`.

See:

- [Ably SDK Team: `sdk.ably.com`: Folder Structure: Tag / Release Folders (`tag`)](https://github.com/ably/engineering/blob/main/sdk/sdk.ably.com.md#tag--release-folders-tag)
- [SDK Team Upload Action: Usage](https://github.com/ably/sdk-upload-action#usage)