### PR TITLE
Add `Message#connectionKey` to IDL

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -2126,6 +2126,7 @@ class Message: // TM*
   +fromEncodedArray(JsonArray, ChannelOptions?) -> [Message] // TM3
   clientId: String? // TM2b
   connectionId: String? // TM2c
+  connectionKey: String? // TM2h
   data: Data? // TM2d
   encoding: String? // TM2e
   extras: JsonObject? // TM2i


### PR DESCRIPTION
The spec point exists but we had forgotten to add to IDL.