### PR TITLE
Fix return type of `batchPresence`

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -1806,7 +1806,7 @@ class RestClient: // RSC*
   time() => io Time // RSC16
   batchPublish(BatchPublishSpec) => io BatchResult<BatchPublishSuccessResult | BatchPublishFailureResult> // RSC22
   batchPublish(BatchPublishSpec[]) => io BatchResult<BatchPublishSuccessResult | BatchPublishFailureResult>[] // RSC22
-  batchPresence(string[]) => io BatchResult<BatchPresenceSuccessResult | BatchPresenceFailureResult>[] // RSC23
+  batchPresence(string[]) => io BatchResult<BatchPresenceSuccessResult | BatchPresenceFailureResult> // RSC23
 
 class RealtimeClient: // RTC*
   constructor(keyOrTokenStr: String) // RTC12


### PR DESCRIPTION
This was a mistake in 038b50e; the API response is a single `BatchResult`. RSC23 was already correct, just the IDL needs changing.