### PR TITLE
Replaced `DeviceDetails` with the `LocalDevice`

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -1163,7 +1163,7 @@ h3(#activation-state-machine). Activation State Machine
 **** @(RSH3b2b)@ Transitions to @NotActivated@.
 *** @(RSH3b3)@ On event @GotPushDeviceDetails@:
 **** @(RSH3b3a)@ If a custom @registerCallback@ was provided to @Push#activate@, pass it the local @DeviceDetails@ updated with the push details.
-**** @(RSH3b3b)@ Otherwise, make an asynchronous HTTP @POST@ request to "/push/deviceRegistrations":/rest-api/#post-device-registration using the local @DeviceDetails@ updated with the push details as body.
+**** @(RSH3b3b)@ Otherwise, make an asynchronous HTTP @POST@ request to "/push/deviceRegistrations":/rest-api/#post-device-registration using the @LocalDevice@ updated with the push details as body (together with the @deviceSecret@).
 **** @(RSH3b3c)@ Either way, when the registration is done, a @GotDeviceRegistration@ or @GettingDeviceRegistrationFailed@ event should be fired.
 **** @(RSH3b3d)@ Transitions to @WaitingForDeviceRegistration@.
 *** @(RSH3b4)@ On event @GettingPushDeviceDetailsFailed@:


### PR DESCRIPTION
 I think mentioning "local DeviceDetails" instead of "LocalDevice" here is a typo. So I don't use the spec modification procedure here ("This clause has been deleted. It was valid up to...") and just editing the current version.. Correct me if it should be a proper spec [replacement](https://github.com/ably/specification/blob/main/CONTRIBUTING.md#features-spec-points).

I've avoided to replace all mentions of "local DeviceDetails" to "LocalDevice", since in places where `deviceSecret` is not used it's not important.