### PR TITLE
Fixed spec for channel subscribe with optional callback

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -687,8 +687,8 @@ h3(#realtime-channel). RealtimeChannel
 ** @(RTL7a)@ Subscribe with a single listener argument subscribes a listener to all messages
 ** @(RTL7b)@ Subscribe with a name argument and a listener argument subscribes a listener to only messages whose @name@ member matches the string name
 ** @(RTL7c)@ This clause has been replaced by "@RTL7g@":#RTL7g. It was valid up to and including specification version @3.0@.
-** @(RTL7g)@ If the @attachOnSubscribe@ channel option is @true@, implicitly attaches the @RealtimeChannel@ if the channel is in the @INITIALIZED@, @DETACHING@, or @DETACHED@ states. The optional callback, if provided, is called according to "@RTL4d@":#RTL4d based on the implicit attach operation. The listener will always be registered regardless of the implicit attach result
-** @(RTL7h)@ If the @attachOnSubscribe@ channel option is @false@, the optional callback must not be called.
+** @(RTL7g)@ If the @attachOnSubscribe@ channel option is @true@, implicitly attaches the @RealtimeChannel@ if the channel is in the @INITIALIZED@, @DETACHING@, or @DETACHED@ states. The optional callback, if provided, is called according to "@RTL4d@":#RTL4d based on the implicit attach operation. The listener will always be registered regardless of the implicit attach result.
+** @(RTL7h)@ If the @attachOnSubscribe@ channel option is @false@, listener is registered without implicit attach and optional callback (if provided) is called indicating success.
 ** @(RTL7d)@ Messages delivered are automatically decoded based on the @encoding@ attribute; see @RestChannel@ encoding features. Tests should exist to publish and subscribe to encoded messages using the "AES 128":https://github.com/ably/ably-common/blob/main/test-resources/crypto-data-128.json and "AES 256":https://github.com/ably/ably-common/blob/main/test-resources/crypto-data-256.json fixture test data
 ** @(RTL7e)@ If a message cannot be decoded or decrypted successfully, it should be delivered to the listener with the @encoding@ attribute set indicating the residual encoding state, and an error should be logged
 ** @(RTL7f)@ A test should exist ensuring published messages are not echoed back to the subscriber when @echoMessages@ is set to false in the @RealtimeClient@ library constructor
@@ -781,8 +781,8 @@ h3(#realtime-presence). RealtimePresence
 ** @(RTP6a)@ Subscribe with a single listener argument subscribes a listener to all presence messages
 ** @(RTP6b)@ Subscribe with an action argument and a listener argument - such as @ENTER@, @LEAVE@, @UPDATE@ or @PRESENT@ - subscribes a listener to receive only presence messages with that action. In lanuages where method overloading is supported the action argument may also be an array of actions to receive only presence messages with an action included in the supplied array.
 ** @(RTP6c)@ This clause has been replaced by "@RTP6d@":#RTP6d. It was valid up to and including specification version @3.0@.
-** @(RTP6d)@ If the @attachOnSubscribe@ channel option is @true@, implicitly attaches the @RealtimeChannel@ if the channel is in the @INITIALIZED@, @DETACHING@, or @DETACHED@ states. The optional callback, if provided, is called according to "@RTL4d@":#RTL4d based on the implicit attach operation. The listener will always be registered regardless of the implicit attach result
-** @(RTP6e)@ If the @attachOnSubscribe@ channel option is @false@, the optional callback must not be called.
+** @(RTP6d)@ If the @attachOnSubscribe@ channel option is @true@, implicitly attaches the @RealtimeChannel@ if the channel is in the @INITIALIZED@, @DETACHING@, or @DETACHED@ states. The optional callback, if provided, is called according to "@RTL4d@":#RTL4d based on the implicit attach operation. The listener will always be registered regardless of the implicit attach result.
+** @(RTP6e)@ If the @attachOnSubscribe@ channel option is @false@, listener is registered without implicit attach and optional callback (if provided) is called indicating success.
 * @(RTP7)@ @RealtimePresence#unsubscribe@ function:
 ** @(RTP7c)@ Unsubscribe with no arguments unsubscribes all listeners
 ** @(RTP7a)@ Unsubscribe with a single listener argument unsubscribes the listener if previously subscribed with an action-specific subscription


### PR DESCRIPTION
- Subscribe method accepts optional callback to indicate success/failure of a specified operation.
- Old spec keeps callback into pending state which is not acceptable and confusing at the same time.
- Updated spec to indicate success when specified operation is successful.
- It wasn't intentional, but same is implemented in ably-java -> 
https://github.com/ably/ably-java/blob/ea94d2a87fee3373a6495bfc11ebaba5394fa6c9/lib/src/main/java/io/ably/lib/realtime/Presence.java#L311-L314



