### PR TITLE
Spec: SUBSCRIBE mode renamed to MESSAGE_SUBSCRIBE

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -1343,7 +1343,8 @@ h4. ProtocolMessage
 ** @(TR3f)@ 5: @ATTACH_RESUME@
 ** @(TR3q)@ 16: @PRESENCE@
 ** @(TR3r)@ 17: @PUBLISH@
-** @(TR3s)@ 18: @SUBSCRIBE@
+** @(TR3s)@ 18: @SUBSCRIBE@ Synonymous with @MESSAGE_SUBSCRIBE@. Retained for backward compatibility.
+** @(TR3u)@ 18: @MESSAGE_SUBSCRIBE@ Synonymous with @SUBSCRIBE@. This variant should be preferred.
 ** @(TR3t)@ 19: @PRESENCE_SUBSCRIBE@
 * @(TR4)@ The attributes available in a @ProtocolMessage@ are:
 ** @(TR4a)@ @action@ enum
@@ -1528,7 +1529,7 @@ h4. ChannelMetrics
 ** @(CHM2c)@ @presenceMembers@ integer - the number of members in the presence set of channel (note: may be larger than presenceConnections since a given connection may enter the presence set multiple times with different clientIds)
 ** @(CHM2d)@ @presenceSubscribers@ integer - the number of realtime attachments which are receiving presence messages on the channel (that is, they have the `subscribe` capability and have not specified a @ChannelMode@ that excludes @PRESENCE_SUBSCRIBE@)
 ** @(CHM2e)@ @publishers@ integer - the number of realtime attachments which are able to publish messages to the channel (that is, they have the `publish` capability and have not specified a @ChannelMode@ that excludes @PUBLISH@)
-** @(CHM2f)@ @subscribers@ integer - the number of realtime attachments which are receiving messages on the channel (that is, they have the `subscribe` capability and have not specified a @ChannelMode@ that excludes @SUBSCRIBE@)
+** @(CHM2f)@ @subscribers@ integer - the number of realtime attachments which are receiving messages on the channel (that is, they have the `subscribe` capability and have not specified a @ChannelMode@ that excludes @SUBSCRIBE@ or synonymously @MESSAGE_SUBSCRIBE@)
 
 h4. BatchResult
 
@@ -2028,6 +2029,7 @@ enum ChannelMode: // TB2d
   PRESENCE
   PUBLISH
   SUBSCRIBE
+  MESSAGE_SUBSCRIBE
   PRESENCE_SUBSCRIBE
 
 class ChannelStateChange: // TH*


### PR DESCRIPTION
The `SUBSCRIBE` channel mode has now been renamed to `MESSAGE_SUBSCRIBE` to better match the existing `PRESENCE_SUBSCRIBE` mode as well as upcoming channel state related modes (to be addressed separately), and for better parity with capability strings.

SEE: https://github.com/ably/realtime/discussions/6352