### PR TITLE
chat: add error code for before publish rule violations

### DIFF
--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -613,6 +613,14 @@ This section contains error codes that are specific to Chat. If a specific error
 For non-chat-specific codes, the status code for the error should align with the error code. For example, error code @40000@ should hav status code @400@.
 
 <pre>
+  // The message was rejected before publishing by a rule on the chat room.
+  // To be accompanied by status code 422
+  MessageRejectedByBeforePublishRule = 42211
+
+  // The message was rejected before publishing by a moderation rule on the chat room.
+  // To be accompanied by status code 422
+  MessageRejectedByModeration = 42213
+
   // The messages feature failed to attach.
   // To be accompanied with status code 500.
   MessagesAttachmentFailed = 102001


### PR DESCRIPTION
Adds the before publish rule rejection error code.

Relates to:

https://github.com/ably/ably-chat-js/pull/396
https://github.com/ably/ably-common/pull/268

[CHA-701]

[CHA-701]: https://ably.atlassian.net/browse/CHA-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ