### PR TITLE
[Chat][Room-Release] Remove CHA-RL3c

### DIFF
--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -116,7 +116,7 @@ h4(#rooms-lifecycle-operations). Room Lifecycle Operations
 ** @(CHA-RL3a)@ @[Testable]@ If the room is already in the @RELEASED@ status, this operation is no-op.
 ** @(CHA-RL3b)@ @[Testable]@ If the room is in the @DETACHED@ status, then the room is immediately transitioned to @RELEASED@ and the operation succeeds.
 ** @(CHA-RL3j)@ @[Testable]@ If the room is in the @INITIALIZED@ status, then the room is immediately transitioned to @RELEASED@ and the operation succeeds.
-** @(CHA-RL3c)@ @[Testable]@ If the room is in the @RELEASING@ status, then the operation will return the result of the pending @release@ operation, or throw any exception that it throws.
+** @(CHA-RL3c)@ This specification point has been removed.
 ** @(CHA-RL3i)@ This specification point has been removed.
 ** @(CHA-RL3l)@ @[Testable]@ When the release operation commences, the room will transition into the @RELEASING@ status and any transient disconnect timeouts shall be cleared.
 ** @(CHA-RL3d)@ @[Testable]@ All features channels must be detached in sequence.


### PR DESCRIPTION
- CHA-RL3c—If the room is in the @RELEASING@ status, the operation will return the result of the pending @release@ operation or throw any exception it throws.
- This statement conflicts with the atomic behavior of the room lifecycle manager [CHA-RL7].
- This also conflicts with [CHA-RL3k], where every new operation starts only after the previous one has finished.
- Also, `release` operation never throws any exceptions and always sets channels into either `detached` or `failed` status, setting RoomStatus as `Released` at the end.
- This means once release operation starts, it will always finish emitting `Releasing` -> `Released` states.
- New `Release` operation will be automatically covered as per CHA-RL3a.
- Related discussion for the same -> https://github.com/ably/ably-chat-js/issues/399