### PR TITLE
chat: remove CHA-M5j

### DIFF
--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -239,7 +239,7 @@ Broadly speaking, messages are published via REST calls to the Chat HTTP API and
 ** @(CHA-M5g)@ @[Testable]@ The subscribers @subscription point@ must be additionally specified (internally, by us) in the @fromSerial@ query parameter.
 ** @(CHA-M5h)@ @[Testable]@ The method must return a standard @PaginatedResult@ , which can be further inspected to paginate across results.
 ** @(CHA-M5i)@ @[Testable]@ If the REST API returns an error, then the method must throw its @ErrorInfo@ representation.
-** @(CHA-M5j)@ @[Testable]@ If the @end@ parameter is specified and is more recent than the @subscription point@ timeserial, the method must throw an @ErrorInfo@ with code @40000@.
+** @(CHA-M5j)@ This specification point has been removed.
 * @(CHA-M6)@ Messages should be queryable from a paginated REST API.
 * @(CHA-M6a)@ @[Testable]@ A method must be exposed that accepts the standard Ably REST API query parameters. It shall call the "REST API"#rest-fetching-messages and return a @PaginatedResult@ containing messages, which can then be paginated through. Each message must be represented by the standard @Message@ object.
 * @(CHA-M6b)@ @[Testable]@ If the REST API returns an error, then the method must throw its @ErrorInfo@ representation.


### PR DESCRIPTION
This specification point is no longer possible now that we do not attempt to parse timeserials.

[CHA-704]

[CHA-704]: https://ably.atlassian.net/browse/CHA-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ