### PR TITLE
Features spec: update TM5 message action

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -1332,7 +1332,7 @@ h3(#types). Data types
 
 h4. Message
 * @(TM1)@ A @Message@ represents an individual message to be sent or received via the Ably Realtime service.
-* @(TM5)@ @Message@ @Action@ enum has the following values in order from zero: @MESSAGE_UNSET@, @MESSAGE_CREATE@, @MESSAGE_UPDATE@, @MESSAGE_DELETE@, @ANNOTATION_CREATE@, @ANNOTATION_DELETE@, @META_OCCUPANCY@
+* @(TM5)@ @Message@ @Action@ enum has the following values in order from zero: @MESSAGE_CREATE@, @MESSAGE_UPDATE@, @MESSAGE_DELETE@, @META_OCCUPANCY@, @MESSAGE_SUMMARY@
 * @(TM2)@ The attributes available in a @Message@ are:
 ** @(TM2a)@ @id@ string - unique ID for this message. This attribute is always populated for messages received over REST. For messages received over Realtime, if the message does not contain an @id@, it should be set to @protocolMsgId:index@, where @protocolMsgId@ is the id of the @ProtocolMessage@ encapsulating it, and @index@ is the index of the message inside the @messages@ array of the @ProtocolMessage@
 ** @(TM2b)@ @clientId@ string
@@ -2181,13 +2181,11 @@ enum PresenceAction: // TP2
   UPDATE // TP2
 
 enum MessageAction: // TM5
-  MESSAGE_UNSET // TM5
   MESSAGE_CREATE // TM5
   MESSAGE_UPDATE // TM5
   MESSAGE_DELETE // TM5
-  ANNOTATION_CREATE // TM5
-  ANNOTATION_DELETE // TM5
   META_OCCUPANCY // TM5
+  MESSAGE_SUMMARY // TM5
 
 class ConnectionDetails: // CD*, internal
   clientId: String? // RSA12a, CD2a


### PR DESCRIPTION
As agreed and implemented in
https://github.com/ably/sdk-api-reference/pull/44#discussion_r1903102862 . Which was before I merged that repo into this, so this change is already made in api-docstrings.md, but needs to be made in the features spec too

This is technically a breaking change, but probably fine to just edit in-place (without changing the api version) since we don't yet have any public functionality that depends on the message action, and we're not planning on making serverside behaviour switch on api version, we're just going to make the change and have the chat sdk (which is what needs this) depend on new enough versions of released sdks