### PR TITLE
Fixed endpoint spec for REC1b1 and REC2c1

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -74,7 +74,7 @@ h2(#endpoint-configuration). Client library endpoint configuration
 * @(REC1)@ Various client options collectively determine a @primary domain@.
 ** @(REC1a)@ The @primary domain@ is @main.realtime.ably.net@ unless overridden by specifying an @endpoint@ option or any of the deprecated options @environment@, @restHost@, @realtimeHost@.
 ** @(REC1b)@ If the @endpoint@ option is specified then:
-*** @(REC1b1)@ If any one of the deprecated options @environment@, @restHost@, @realtimeHost@ are also specified then the options as a set are invalid.
+*** @(REC1b1)@ If any one of the deprecated options @environment@, @restHost@, @realtimeHost@ or @fallbackHostsUseDefault@ are also specified then the options as a set are invalid.
 *** @(REC1b2)@ If the @endpoint@ option is a domain name, determined by it containing at least one period (@.@) then the @primary domain@ is the value of the @endpoint@ option.
 *** @(REC1b3)@ Otherwise, if the @endpoint@ option is a non-production routing policy name of the form @nonprod:[name]@ then the @primary domain@ is @[name].realtime.ably-nonprod.net@.
 *** @(REC1b4)@ Otherwise, if the @endpoint@ option is a production routing policy name of the form @[name]@ then the @primary domain@ is @[name].realtime.ably.net@.
@@ -91,7 +91,7 @@ h2(#endpoint-configuration). Client library endpoint configuration
 *** @(REC2a2)@ Otherwise, the set of @fallback domains@ is given by the value of the @fallbackHosts@ option.
 ** @(REC2b)@ Otherwise, if the deprecated @fallbackHostsUseDefault@ option is specified then the set of @fallback domains@ is the default set defined in @(REC2c1)@.
 ** @(REC2c)@ Otherwise, the set of @fallback domains@ is defined implicitly by the options used to define the @primary domain@ as specified in @(REC1)@:
-*** @(REC2c1)@ If the @primary domain@ is determined to be the default via @(REC1a)@ then the set of @fallback domains@ is the default @a.ably-realtime.com@, @b.ably-realtime.com@, @c.ably-realtime.com@, @d.ably-realtime.com@, and @e.ably-realtime.com@.
+*** @(REC2c1)@ If the @primary domain@ is determined to be the default via @(REC1a)@ then the set of @fallback domains@ is the default @main.a.fallback.ably-realtime.com@, @main.b.fallback.ably-realtime.com@, @main.c.fallback.ably-realtime.com@, @main.d.fallback.ably-realtime.com@, and @main.e.fallback.ably-realtime.com@.
 *** @(REC2c2)@ Otherwise, if the @primary domain@ is determined to be an explicit domain name via @(REC1b2)@ then the set of @fallback domains@ is empty.
 *** @(REC2c3)@ Otherwise, if the @primary domain@ is determined to be a non-production routing policy name via @(REC1b3)@ then the set of @fallback domains@ is @[name].a.fallback.ably-realtime-nonprod.com@, @[name].b.fallback.ably-realtime-nonprod.com@, @[name].c.fallback.ably-realtime-nonprod.com@, @[name].d.fallback.ably-realtime-nonprod.com@, @[name].e.fallback.ably-realtime-nonprod.com@.
 *** @(REC2c4)@ Otherwise, if the @primary domain@ is determined to be a production routing policy name via @(REC1b4)@ then the set of @fallback domains@ is @[name].a.fallback.ably-realtime.com@, @[name].b.fallback.ably-realtime.com@, @[name].c.fallback.ably-realtime.com@, @[name].d.fallback.ably-realtime.com@, @[name].e.fallback.ably-realtime.com@.


### PR DESCRIPTION
- `REC1b1` forgot to mention one more deprecated clientOption `fallbackHostsUseDefault`.
- Updated `REC2c1` to use new default fallback hosts 