### PR TITLE
Refactor: Spec updates for Typing presence to heartbeat-based changes

### DIFF
--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -425,8 +425,8 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 * @(CHA-T9)@ @[Testable]@ Users must be able to retrieve a list of the currently typing client IDs through a @typing.get()@ method. The list must be a copy of the up-to-date internal list of typing client IDs.
 * @(CHA-T15)@ @[Testable]@ Users must be able to provide a listener to subscribe to new typing events that the Chat client emits. This operation must have no side effects on the status of the room or the underlying realtime channel.
 * @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the no-op period for @typing.keystroke@ when the heartbeat timer is set active at @CHA-T4a4@). This configuration is provided at the @RoomOptions.typing.heartbeatThrottleMs@ property, or idiomatic equivalent. The default is 10000ms.
-** @(CHA-T10a)@ @[Testable]@ A grace period shall be set by the client (the grace period on the @CHA-T10@ heartbeat interval when receiving events). The value shall be set to 2000ms.
-*** @(CHA-T10a1)@ @[Testable]@ If a @typing.start@ event is not received within this period, the client shall assume that the user has stopped typing. For example, if the client has not received a @typing.start@ event within 12000ms of the last heartbeat (10s heartbeat interval plus 2s grace period), the client shall assume that the user has stopped typing and emit a @typing.stopped@ event for that user to all registered listeners @(CHA-T15)@.
+** @(CHA-T10a)@ A grace period shall be set by the client (the grace period on the @CHA-T10@ heartbeat interval when receiving events). The default value shall be set to 2000ms.
+*** @(CHA-T10a1)@ This grace period is used to determine how long to wait, beyond the heartbeat interval, before removing a client from the typing set. This is used to prevent flickering when a user is typing and stops typing for a short period of time. See @CHA-T13b1@ for a detailed description of how this is used.
 * @(CHA-T3)@ This specification point has been removed. It was replaced by @CHA-T10@.
 * @(CHA-T4)@ Users may indicate that they have started typing using the @keystroke@ method.
 ** @(CHA-T4d)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
@@ -435,14 +435,16 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 *** @(CHA-T4a2)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a3)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the @name@ field set to @typing.started@, the format of which is detailed "here":#realtime-typing-message.
 *** @(CHA-T4a4)@ @[Testable]@ Upon successful publish, a heartbeat timer shall be set according to the @CHA-T10@ timeout interval.
+*** @(CHA-T4a5)@ @[Testable]@ The client must wait for the publish to succeed or fail before returning the result to the caller. If the publish fails, the client must throw an @ErrorInfo@.
 ** @(CHA-T4b)@ This specification point has been removed. It was superseded by @CHA-T4c@.
 ** @(CHA-T4c)@ If typing is already in progress (i.e. a heartbeat timer set according to @CHA-T4a4@ exists and has not expired):
-*** @(CHA-T4c1)@ @[Testable]@ The client must not send a @typing.started@ event.
+*** @(CHA-T4c1)@ @[Testable]@ The client must not send a @typing.started@ event, instead it shall return a successful no-op to the caller.
 * @(CHA-T5)@ Users may explicitly indicate that they have stopped typing using @stop@ method.
 ** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. a @CHA-T10@ heartbeat timer does not exist or is expired), this operation is a no-op.
 ** @(CHA-T5b)@ This specification point has been removed.
 ** @(CHA-T5c)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
-** @(CHA-T5d)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-message.
+** @(CHA-T5d)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-message. The client must wait for the publish to succeed or fail before returning the result to the caller.
+** @(CHA-T5d1)@ @[Testable]@ The client must wait for the publish to succeed or fail before returning the result to the caller. If the publish fails, the client must throw an @ErrorInfo@.
 ** @(CHA-T5e)@ @[Testable]@ On successfully publishing the message in @(CHA-T5d)@, the @CHA-T10@ timer shall be unset.
 * @(CHA-T6)@ Users may subscribe to typing events - updates to a set of clientIDs that are typing. This operation, like all subscription operations, has no side-effects in relation to room lifecycle.
 ** @(CHA-T6a)@ @[Testable]@ Users may provide a listener to subscribe to "typing event V2":#chat-structs-typing-event-V2 in a chat room.
@@ -455,13 +457,14 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 ** @(CHA-T13b)@ @[Testable]@ When a typing event is received on the realtime client:
 *** @(CHA-T13b1)@ @[Testable]@ If the event represents a new client typing, then the Chat client shall add the typers clientId (@msg.clientId@) to the typing set and a emit the updated set, via a new "typing event":#chat-structs-typing-event-V2 , to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ graсe period.
 *** @(CHA-T13b2)@ @[Testable]@ Each additional @typing.started@ event from the same client shall reset the @(CHA-T13b1)@ timeout for that client.
-*** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the clientId from the typing set and emit a typing stop event for the given client to all registered listeners (@(CHA-T15)@).
-*** @(CHA-T13b4)@ @[Testable]@ If the event represents a client that has stopped typing, the Chat client shall remove the clientId from the typing set and emit the updated set to any registered listeners (@(CHA-T15)@). It shall also cancel the @(CHA-T13b1)@ timeout for that typer.
-*** @(CHA-T13b5)@ @[Testable]@ If the event represents a client that has stopped typing, but the clientId for that client is not present in the typing set, then no event shall be emitted to any registered listeners (@(CHA-T15)@).
+*** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the clientId from the typing set and emit a typing stop event for the given client to all registered listeners (@CHA-T15@).
+*** @(CHA-T13b4)@ @[Testable]@ If the event represents a client that has stopped typing, the Chat client shall remove the clientId from the typing set and emit the updated set to any registered listeners (@CHA-T15@). It shall also cancel the @(CHA-T13b1)@ timeout for that typer.
+*** @(CHA-T13b5)@ @[Testable]@ If the event represents a client that has stopped typing, but the clientId for that client is not present in the typing set, then no event shall be emitted to any registered listeners (@CHA-T15@).
 * @(CHA-T14)@ @[Testable]@ Multiple asynchronous calls to keystroke/stop typing must eventually converge to a consistent state.
-** @(CHA-TM14a)@ When a call to @keystroke@ or @stop@ is made, it should attempt to acquire a mutex lock.
-** @(CHA-TM14b)@ Once the lock is acquired, if another call is made to either function, the second call shall be queued and wait until it can acquire the lock before executing.
-*** @(CHA-TM14b1)@ During this time, each new subsequent call to either function shall abort the previously queued call. In doing so, there shall only ever be one pending call and while the mutex is held, thus the most recent call shall "win" and execute once the mutex is released.
+** @(CHA-TM14a)@ @[Testable]@ When a call to @keystroke@ or @stop@ is made, it should attempt to acquire a mutex lock.
+** @(CHA-TM14b)@ @[Testable]@ Once the lock is acquired, if another call is made to either function, the second call shall be queued and wait until it can acquire the lock before executing.
+*** @(CHA-TM14b1)@ @[Testable]@ During this time, each new subsequent call to either function shall abort the previously queued call, this should be registered as a successful no-op to the caller. In doing so, there shall only ever be one pending call while the mutex is held, thus the most recent call shall "win" and execute once the mutex is released.
+*** @(CHA-TM14b2)@ @[Testable]@ If an error occurs while the lock is held, the mutex shall be released and the error shall be thrown to the caller.
 
 h2(#occupancy). Occupancy
 

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -438,7 +438,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 ** @(CHA-T4c)@ If typing is already in progress (i.e. a heartbeat timer set according to @CHA-T4a4@ exists and has not expired):
 *** @(CHA-T4c1)@ @[Testable]@ The client must not send a @typing.started@ event.
 * @(CHA-T5)@ Users may explicitly indicate that they have stopped typing using @stop@ method.
-** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. a @CHA-T10@ heartbeat timer exists and has not expired), this operation is a no-op.
+** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. a @CHA-T10@ heartbeat timer does not exist or is expired), this operation is a no-op.
 ** @(CHA-T5b)@ This specification point has been removed.
 ** @(CHA-T5c)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
 ** @(CHA-T5d)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-heartbeat.
@@ -450,7 +450,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 *** @(CHA-T6c1)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
 *** @(CHA-T6c2)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
 * @(CHA-T13)@ When a typing event (@typing.start@ or @typing.stop@) is received from the realtime client, the Chat client shall emit appropriate events to the user.
-** @(CHA-T13a)@ @[Testable]@ If the typing event is malformed (unknown fields should be ignored), then it shall not be emitted to the subscriber.
+** @(CHA-T13a)@ @[Testable]@ If the typing event received from the server is malformed, i.e does not conform to the expected "payload":#realtime-typing-events (unknown fields should be ignored), then it shall not be handled and emitted to the subscriber.
 ** @(CHA-T13b)@ @[Testable]@ When a typing event is received from the realtime client:
 *** @(CHA-T13b1)@ @[Testable]@ If the event represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ graсe period.
 *** @(CHA-T13b2)@ @[Testable]@ Each additional typing heartbeat from the same client shall reset the @(CHA-T13b1)@ timeout.

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -423,9 +423,9 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 * @(CHA-T2)@ This specification point has been removed. It was replaced by @CHA-T9@.
 * @(CHA-T8)@ Typing Indicators for a Room are exposed on the main room channel, in the format @<roomId>::$chat@. For example, if your room id is @my-room@ then the channel will be @my-room::$chat@.
 * @(CHA-T9)@ @[Testable]@ Users may retrieve a list of the currently typing client IDs.
-* @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the period between typing heartbeats sent by the client). This configuration is provided at the @RoomOptions.typing.heartbeatIntervalMs@ property, or idiomatic equivalent. The default is 15000ms.
+* @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the period between typing heartbeats sent by the client). This configuration is provided at the @RoomOptions.typing.heartbeatThrottleMs@ property, or idiomatic equivalent. The default is 10000ms.
 ** @(CHA-T10a)@ @[Testable]@ A grace period shall be set by the client (the grace period on the @CHA-T10@ heartbeat interval when receiving heartbeats). The value shall be set to 2000ms.
-*** @(CHA-T10a1)@ @[Testable]@ If a heartbeat is not received within this period, the client shall assume that the user has stopped typing. For example, if the client has not received a heartbeat within 17000ms of the last heartbeat (15s heartbeat interval plus 2s grace period), the client shall assume that the user has stopped typing.
+*** @(CHA-T10a1)@ @[Testable]@ If a heartbeat is not received within this period, the client shall assume that the user has stopped typing. For example, if the client has not received a heartbeat within 12000ms of the last heartbeat (10s heartbeat interval plus 2s grace period), the client shall assume that the user has stopped typing.
 * @(CHA-T4)@ Users may indicate that they have started typing.
 ** @(CHA-T4d)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
 ** @(CHA-T4a)@ If typing is not already in progress (i.e. a @CHA-T10@ timeout has not been defined):

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -423,33 +423,25 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 * @(CHA-T2)@ This specification point has been removed. It was replaced by @CHA-T9@.
 * @(CHA-T8)@ Typing Indicators for a Room are exposed on the main room channel, in the format @<roomId>::$chat@. For example, if your room id is @my-room@ then the channel will be @my-room::$chat@.
 * @(CHA-T9)@ @[Testable]@ Users may retrieve a list of the currently typing client IDs.
-* @(CHA-T3)@ @[Testable]@ Users may configure a typing timeout interval (the time after which the client will assume the user has stopped typing). This configuration is provided at the @RoomOptions.typing.timeoutMs@ property, or idiomatic equivalent. The default value is unset.
 * @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the period between typing heartbeats sent by the client). This configuration is provided at the @RoomOptions.typing.heartbeatIntervalMs@ property, or idiomatic equivalent. The default is 15000ms.
-* @(CHA-T11)@ @[Testable]@ Users may configure an inactivity timeout interval (the grace period on the @CHA-T10@ heartbeat interval when receiving heartbeats). This configuration is provided as part of the @RoomOptions@ @typing.inactivityTimeoutMs@ property, or idiomatic equivalent. The default is 500ms.
+** @(CHA-T10a)@ @[Testable]@ A grace period shall be set by the client (the grace period on the @CHA-T10@ heartbeat interval when receiving heartbeats). The value shall be set to 2000ms.
+*** @(CHA-T10a1)@ @[Testable]@ If a heartbeat is not received within this period, the client shall assume that the user has stopped typing. For example, if the client has not received a heartbeat within 17000ms of the last heartbeat (15s heartbeat interval plus 2s grace period), the client shall assume that the user has stopped typing.
 * @(CHA-T4)@ Users may indicate that they have started typing.
 ** @(CHA-T4d)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
 ** @(CHA-T4a)@ If typing is not already in progress (i.e. a @CHA-T10@ timeout has not been defined):
 *** @(CHA-T4a1)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a2)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a3)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.started@, the format of which is detailed "here":#realtime-typing-heartbeat.
-*** @(CHA-T4a4)@ @[Testable]@ Upon successful publish, if a value for the @CHA-T3@ timeout interval is defined, a timeout shall be created.
-*** @(CHA-T4a5)@ @[Testable]@ Upon successful publish, a timeout shall be set according to the @CHA-T10@ timeout interval.
+*** @(CHA-T4a4)@ @[Testable]@ Upon successful publish, a timeout shall be set according to the @CHA-T10@ timeout interval.
 ** @(CHA-T4b)@ This specification point has been removed. It was superseded by @CHA-T4c@.
 ** @(CHA-T4c)@ If typing is already in progress (i.e. a @CHA-T10@ timeout has been defined):
 *** @(CHA-T4c1)@ @[Testable]@ The client must not send a @typing.started@ event.
-*** @(CHA-T4c2)@ @[Testable]@ If defined, the @CHA-T3@ timeout interval must be reset to @timeoutMs@ from now.
-* @(CHA-T12)@ Users may stop typing implicitly via lack of activity.
-** @(CHA-T12a)@ @[Testable]@ If a @CHA-T10@ timeout expires, then the @CHA-T10@ timeout must be unset. The client shall not send any messages on the channel.
-** @(CHA-T12b)@ @[Testable]@ If a @CHA-T3@ timeout expires, then the client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-heartbeat.
-*** @(CHA-T12b1)@ @[Testable]@ Upon successful publish, the @CHA-T10@ timeout must be unset.
-*** @(CHA-T12b2)@ @[Testable]@ Upon failed publish, the client must log this happening with the error as part of the log context and take no further action.
-*** @(CHA-T12b3)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, client must log this happening with the error as part of the log context and take no further action.
 * @(CHA-T5)@ Users may explicitly indicate that they have stopped typing.
 ** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. no @CHA-T10@ timeout has been defined), this operation is no-op.
 ** @(CHA-T5b)@ This specification point has been removed.
 ** @(CHA-T5c)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
 ** @(CHA-T5d)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-heartbeat.
-** @(CHA-T5e)@ @[Testable]@ On successfully publishing the message in @(CHA-T5d)@, the @CHA-T3@ and @CHA-T10@ timers shall be unset.
+** @(CHA-T5e)@ @[Testable]@ On successfully publishing the message in @(CHA-T5d)@, the @CHA-T10@ timer shall be unset.
 * @(CHA-T6)@ Users may subscribe to typing events - updates to a set of clientIDs that are typing. This operation, like all subscription operations, has no side-effects in relation to room lifecycle.
 ** @(CHA-T6a)@ @[Testable]@ Users may provide a listener to subscribe to "typing event V2":#chat-structs-typing-event-V2 in a chat room.
 ** @(CHA-T6b)@ @[Testable]@ A subscription to typing may be removed, after which it shall receive no further events.
@@ -459,7 +451,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 * @(CHA-T13)@ When a typing heartbeat is received from the realtime client, the Chat client shall emit appropriate events to the user.
 ** @(CHA-T13a)@ @[Testable]@ If the typing heartbeat is malformed (unknown fields should be ignored), then it shall not be emitted to the subscriber.
 ** @(CHA-T13b)@ @[Testable]@ When a typing heartbeat is received from the realtime client;
-*** @(CHA-T13b1)@ @[Testable]@ If the heartbeat represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T11@ grade period.
+*** @(CHA-T13b1)@ @[Testable]@ If the heartbeat represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ grade period.
 *** @(CHA-T13b2)@ @[Testable]@ Each additional typing heartbeat from the same client shall reset the @(CHA-T13b1)@ timeout.
 *** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the subject from the typing set and emitting the updated set to any subscribers.
 *** @(CHA-T13b4)@ @[Testable]@ If the heartbeat represents a client that has stopped typing, then the chat client shall remove the typer from the typing set and emit the updated set to any subscribers. It shall also cancel the @(CHA-T13b1)@ timeout for the typing client.

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -412,43 +412,42 @@ Presence allows chat room users to indicate to others that they're online, as we
 h2(#typing). Typing Indicators
 
 Typing Indicators allow chat room users to indicate to others that they are typing. This is most common in 1:1 and community chat, where the client would display "Alice and Bob are typing..." to users.
-@(deprecated)@ This system is presence-based, to avoid the cost of heartbeat/polling messages, with entering presence deemed to mean "started typing" and leaving presence deemed to mean "stopped typing".
 
-This system uses heartbeat messages, alongside specific message metadata (TBD) which disables persistence for them, reducing the cost of servicing the heartbeats.
+This system uses ephemeral non-persisted heartbeat messages. They do not appear in channel history, resume or rewind.
 
 @Typing Indicators@ shall be exposed to consumers via the @typing@ property of a @Room@.
 
-* @(CHA-T1)@ @(deprecated)@ Typing Indicators for a Room is exposed on a dedicated Realtime channel. These channels use the format @<roomId>::$chat::$typingIndicators@. For example, if your room id is @my-room@ then the typing channel will be @my-room::$chat::$typingIndicators@.
-* @(CHA-T2)@ @(deprecated)@ @[Testable]@ Users may retrieve a list of the currently typing client IDs. The behaviour depends on the current room status, as presence operations in a Realtime Client cause implicit attaches.
-* @(CHA-T8)@ Typing Indicators for a Room is exposed on the channel used for chat messages, in the format @<roomId>::$chat::$chatMessages@. For example, if your room id is @my-room@ then the presence channel will be @my-room::$chat::$chatMessages@.
+For the purpose of this section, an @ephemeral message@ is understood to mean a regular message where @message.extras.ephemeral@ is set to @true@.
+
+* @(CHA-T1)@ This specification point has been removed. It was superseded by @CHA-T8@.
+* @(CHA-T2)@ This specification point has been removed. It was replaced by @CHA-T9@.
+* @(CHA-T8)@ Typing Indicators for a Room are exposed on the main rom channel, in the format @<roomId>::$chat@. For example, if your room id is @my-room@ then the channel will be @my-room::$chat@.
 * @(CHA-T9)@ @[Testable]@ Users may retrieve a list of the currently typing client IDs.
-** @(CHA-T2b)@ This specification point has been removed.
-*** @(CHA-T2b1)@ This specification point has been removed.
-*** @(CHA-T2b2)@ This specification point has been removed.
-** @(CHA-T2c)@ @(deprecated)@ @[Testable]@ If the room status is @Attaching@, then the operation shall invoke a @CHA-RL9@ pending room status operation and wait for it to complete. If this operation fails, then the error from @CHA-RL9@ must be raised. If this succeeds (i.e the room becomes @ATTACHED@), the library must invoke the underlying @presence.get()@ call.
-** @(CHA-T2g)@ @(deprecated)@ @[Testable]@ If the room status is anything other than @Attached@ or @Attaching@, an @ErrorInfo@ using the @RoomInInvalidState@ error code from the "chat-specific error codes":#error-codes with a status code of @400@ must be thrown. The message shall explain that attach must be called first.
-** @(CHA-T2d)@ @(deprecated)@ @[Testable]@ If the room status is @Attached@, then the @get@ call shall invoke the underlying @presence.enter()@ call.
-
-** @(CHA-T2e)@ This specification point has been removed. It was superseded by @CHA-T2g@.
-** @(CHA-T2f)@ This specification point has been removed. It was superseded by @CHA-T2g@.
-* @(CHA-T3)@ @[Testable]@ Users may configure a timeout interval for when they are typing. This configuration is provided as part of the @RoomOptions@ @typing.timeoutMs@ property, or idiomatic equivalent. The default is 5000ms.
-* @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval for when they are typing. This configuration is provided as part of the @RoomOptions@ @typing.heartbeatIntervalMs@ property, or idiomatic equivalent. The default is 15000ms.
-* @(CHA-T11)@ @[Testable]@ Users may configure an inactivity timeout interval for when they are receiving heartbeats from other users. This configuration is provided as part of the @RoomOptions@ @typing.inactivityTimeoutMs@ property, or idiomatic equivalent. The default is 2000ms.
+* @(CHA-T3)@ @[Testable]@ Users may configure a typing timeout interval (the time after which the client will assume the user has stopped typing). This configuration is provided as part of the @RoomOptions@ @typing.timeoutMs@ property, or idiomatic equivalent. The default value is unset.
+* @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the period between typing heartbeats sent by the client). This configuration is provided as part of the @RoomOptions@ @typing.heartbeatIntervalMs@ property, or idiomatic equivalent. The default is 15000ms.
+* @(CHA-T11)@ @[Testable]@ Users may configure an inactivity timeout interval (the grace period on the @CHA-T10@ heartbeat interval when receiving heartbeats). This configuration is provided as part of the @RoomOptions@ @typing.inactivityTimeoutMs@ property, or idiomatic equivalent. The default is 2000ms.
 * @(CHA-T4)@ Users may indicate that they have started typing.
-** @(CHA-T4a)@ @[Testable]@ If typing is not already in progress, per explicit cancellation or the timeout interval in (@CHA-T3@), then a new typing session is started.
-*** @(CHA-T4a1)@ @(deprecated)@ @[Testable]@ When a typing session is started, the client is entered into presence on the typing channel.
-*** @(CHA-T4a2)@ @(deprecated)@ @[Testable]@ When a typing session is started, a timeout is set according to the @CHA-T3@ timeout interval. When this timeout expires, the typing session is automatically ended by leaving presence.
-
-*** @(CHA-T4a3)@ @[Testable]@ When a typing session is started, the client shall publish a heartbeat message with the name field set to `typing.started`, the format of which is detailed "here":#realtime-typing-heartbeat.
-*** @(CHA-T4a4)@ @[Testable]@ When a typing session is started, a timeout shall be set according to the @CHA-T3@ timeout interval, if the interval is undefined, no timout shall be set. When this timeout expires, the client shall publish a heartbeat message with the name field set to `typing.stopped`, the format of which is detailed "here":#realtime-typing-heartbeat.
-*** @(CHA-T4a5)@ @[Testable]@ When a typing session is started, a timeout shall be set according to the @CHA-T10@ timeout interval. Until this timeout expires, the client shall not publish any further `typing.started` "heartbeats":#realtime-typing-heartbeat.
-
-** @(CHA-T4b)@ @[Testable]@ If typing is already in progress, the @CHA-T3@ timeout is extended to be @timeoutMs@ from now.
-** @(CHA-T4c)@ @[Testable]@ If typing is already in progress, the client shall not publish any further `typing.started` heartbeats until the @CHA-T10@ timeout expires. After expiration, if the client is still typing, it shall publish a `typing.started` "heartbeat":#realtime-typing-heartbeat and restart the @CHA-T10@ timeout.
-
-* @(CHA-T5)@ Users may indicate that they have stopped typing.
-** @(CHA-T5a)@ @[Testable]@ If typing is not in progress, this operation is no-op.
-** @(CHA-T5b)@ @(deprecated)@ @[Testable]@ If typing is in progress, the @CHA-T3@ timeout is cancelled. The client then leaves presence.
+** @(CHA-T4d)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
+** @(CHA-T4a)@ If typing is not already in progress (i.e. a @CHA-T10@ timeout has not been defined):
+*** @(CHA-T4a1)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
+*** @(CHA-T4a2)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
+*** @(CHA-T4a3)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.started@, the format of which is detailed "here":#realtime-typing-heartbeat.
+*** @(CHA-T4a4)@ @[Testable]@ Upon successful publish, a timeout shall be set according to the @CHA-T3@ timeout interval, if the interval is undefined, no timeout shall be set. When this timeout expires, the client shall publish a heartbeat message with the name field set to `typing.stopped`, the format of which is detailed "here":#realtime-typing-heartbeat.
+*** @(CHA-T4a5)@ @[Testable]@ Upon successful publish, a timeout shall be set according to the @CHA-T10@ timeout interval. Until this timeout expires, the client shall not publish any further `typing.started` "heartbeats":#realtime-typing-heartbeat.
+** @(CHA-T4b)@ This specification point has been removed. It was superseded by @CHA-T4c@.
+** @(CHA-T4c)@ If typing is already in progress (i.e. a @CHA-T10@ timeout has been defined):
+*** @(CHA-T4c1)@ @[Testable]@ The client must not send a @typing.started@ event.
+*** @(CHA-T4c2)@ @[Testable]@ If defined, the @CHA-T3@ timeout interval must be reset to @timeoutMs@ from now.
+* @(CHA-T12)@ Users may stop typing implicitly via lack of activity.
+** @(CHA-T12a)@ @[Testable]@ If a @CHA-T10@ timeout expires, then the @CHA-T10@ timeout must be unset. The client shall not send any messages on the channel.
+** @(CHA-T12b)@ @[Testable]@ If a @CHA-T3@ timeout expires, then the client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-heartbeat.
+*** @(CHA-T12b1)@ @[Testable]@ Upon successful publish, the @CHA-T10@ timeout must be unset.
+*** @(CHA-T12b2)@ @[Testable]@ Upon failed publish, the client must log this happening with the error as part of the log context and take no further action.
+*** @(CHA-T12b3)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, client must log this happening with the error as part of the log context and take no further action.
+* @(CHA-T5)@ Users may explicitly indicate that they have stopped typing.
+** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. no @CHA-T10@ timeout has been defined), this operation is no-op.
+** @(CHA-T5b)@ This specification point has been removed.
+** @(CHA-T5c)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
 ** @(CHA-T5b)@ @(deprecated)@ @[Testable]@ If typing is in progress, the @CHA-T3@ and @CHA-T10@ timeouts shall be cancelled, and the client shall publish a heartbeat message with the name field set to `typing.stopped`.
 * @(CHA-T6)@ Users may subscribe to typing events - updates to a set of clientIDs that are typing. This operation, like all subscription operations, has no side-effects in relation to room lifecycle.
 ** @(CHA-T6a)@ @[Testable]@ Users may provide a listener to subscribe to "typing event V1":#chat-structs-typing-event in a room. Note, "typing event V1":#chat-structs-typing-event is a deprecated, please use "typing event V2":#chat-structs-typing-event-V2.
@@ -799,14 +798,13 @@ h3(#realtime-room-reactions). Ephemeral Room Reactions
   }
 </pre>
 
-h3(#realtime-typing-heartbeats). Typing Heartbeats
+h3(#realtime-typing-events). Typing Events
 
 <pre>
   {
     "name": "typing.started" | "typing.stopped"
     "encoding": "json"
-    "data": {}
-    },
+    "data": nil
     "timestamp": "1726232498871", // Only on incoming messages
     "extras": {}
   }

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -966,8 +966,10 @@ h3(#chat-structs-typing-event-V2). Typing Event V2
 
 <pre>
   {
-    "event": "typing.started" | "typing.stopped",
-    "clientId": "clientId-2",
+    "change": {
+        "event": "typing.started",
+        "clientId": "clientId-2",
+    },
     "currentlyTyping": ["clientId-1", "clientID-2"],
   }
 </pre>

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -411,7 +411,7 @@ Presence allows chat room users to indicate to others that they're online, as we
 
 h2(#typing). Typing Indicators
 
-Typing Indicators allow chat room users to indicate to others that they are typing. This is most common in 1:1 and community chat, where the client would display "Alice and Bob are typing..." to users.
+Typing Indicators allow chat room users to indicate to others that they are typing. This is most common in 1:1 and community chat, where a UI would display somthing like "Alice and Bob are typing..." to users.
 
 This system uses ephemeral non-persisted heartbeat messages. They do not appear in channel history, resume or rewind.
 
@@ -453,13 +453,13 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 *** @(CHA-T6c1)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
 *** @(CHA-T6c2)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
 * @(CHA-T13)@ When a typing event (@typing.start@ or @typing.stop@) is received from the realtime client, the Chat client shall emit appropriate events to all registered listeners @(CHA-T15)@.
-** @(CHA-T13a)@ @[Testable]@ If the typing event received from the server is malformed, i.e does not conform to the expected "payload":#realtime-typing-message (unknown fields should be ignored), then it shall not be handled and emitted to the subscriber.
+** @(CHA-T13a)@ @[Testable]@ Typing events received from the server must have a valid @clientId@ and must not be malformed, i.e they must conform to the expected "payload":#realtime-typing-message (unknown fields should be ignored). Invalid events shall not be handled or emitted to any registered listeners (@CHA-T15@).
 ** @(CHA-T13b)@ @[Testable]@ When a typing event is received on the realtime client:
-*** @(CHA-T13b1)@ @[Testable]@ If the event represents a new client typing, then the Chat client shall add the typers clientId (@msg.clientId@) to the typing set and a emit the updated set, via a new "typing event":#chat-structs-typing-event-V2 , to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ graсe period.
-*** @(CHA-T13b2)@ @[Testable]@ Each additional @typing.started@ event from the same client shall reset the @(CHA-T13b1)@ timeout for that client.
-*** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the clientId from the typing set and emit a typing stop event for the given client to all registered listeners (@CHA-T15@).
-*** @(CHA-T13b4)@ @[Testable]@ If the event represents a client that has stopped typing, the Chat client shall remove the clientId from the typing set and emit the updated set to any registered listeners (@CHA-T15@). It shall also cancel the @(CHA-T13b1)@ timeout for that typer.
-*** @(CHA-T13b5)@ @[Testable]@ If the event represents a client that has stopped typing, but the clientId for that client is not present in the typing set, then no event shall be emitted to any registered listeners (@CHA-T15@).
+*** @(CHA-T13b1)@ @[Testable]@ If the event represents a new client typing, then the Chat client shall add the typers @clientId@ to the typing set and a emit the updated set, via a new "typing event":#chat-structs-typing-event-V2 , to any listeners. It shall also begin a timer with a timeout period that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ graсe period.
+*** @(CHA-T13b2)@ @[Testable]@ Each additional @typing.started@ event from the same client shall reset the @(CHA-T13b1)@ timer for that client.
+*** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timer expires, the client shall remove the @clientId@ from the typing set and emit a typing stopped event for the given client to all registered listeners (@CHA-T15@).
+*** @(CHA-T13b4)@ @[Testable]@ If the event represents a client that has stopped typing, the Chat client shall remove the @clientId@ from the typing set and emit a typing stopped event to any registered listeners (@CHA-T15@). It shall also cancel the @(CHA-T13b1)@ timer for that the given typing client.
+*** @(CHA-T13b5)@ @[Testable]@ If the event represents a client that has stopped typing, but the @clientId@ for that client is not present in the typing set, then no stop typing event shall be emitted to any registered listeners (@CHA-T15@).
 * @(CHA-T14)@ @[Testable]@ Multiple asynchronous calls to keystroke/stop typing must eventually converge to a consistent state.
 ** @(CHA-TM14a)@ @[Testable]@ When a call to @keystroke@ or @stop@ is made, it should attempt to acquire a mutex lock.
 ** @(CHA-TM14b)@ @[Testable]@ Once the lock is acquired, if another call is made to either function, the second call shall be queued and wait until it can acquire the lock before executing.
@@ -806,7 +806,7 @@ h3(#realtime-typing-message). Typing Message
 <pre>
   {
     "name": "typing.started" // Required, must be either "typing.started" or "typing.stopped"
-    "clientId": "who-is-typing", // Required, cannot be empty string or null
+    "clientId": "who-is-typing", // Required, cannot be empty string or null - This is automatically set by the underlying pubsub SDK.
     "extras": { "ephemeral": true } // Required, must be set to true
   }
 </pre>

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -426,6 +426,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 * @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the no-op period for @typing.keystroke@ when the heartbeat timer is set active at @CHA-T4a4@). This configuration is provided at the @RoomOptions.typing.heartbeatThrottleMs@ property, or idiomatic equivalent. The default is 10000ms.
 ** @(CHA-T10a)@ @[Testable]@ A grace period shall be set by the client (the grace period on the @CHA-T10@ heartbeat interval when receiving heartbeats). The value shall be set to 2000ms.
 *** @(CHA-T10a1)@ @[Testable]@ If a @typing.start@ event is not received within this period, the client shall assume that the user has stopped typing. For example, if the client has not received a @typing.start@ event within 12000ms of the last heartbeat (10s heartbeat interval plus 2s grace period), the client shall assume that the user has stopped typing.
+* @(CHA-T3)@ This specification point has been removed. It was replaced by @CHA-T10@.
 * @(CHA-T4)@ Users may indicate that they have started typing using the @keystroke@ method.
 ** @(CHA-T4d)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
 ** @(CHA-T4a)@ If typing is not already in progress (i.e. a heartbeat timer not set on successful publish @CHA-T4a4@):

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -428,13 +428,13 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 *** @(CHA-T10a1)@ @[Testable]@ If a heartbeat is not received within this period, the client shall assume that the user has stopped typing. For example, if the client has not received a heartbeat within 12000ms of the last heartbeat (10s heartbeat interval plus 2s grace period), the client shall assume that the user has stopped typing.
 * @(CHA-T4)@ Users may indicate that they have started typing.
 ** @(CHA-T4d)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
-** @(CHA-T4a)@ If typing is not already in progress (i.e. a @CHA-T10@ timeout has not been defined):
+** @(CHA-T4a)@ If typing is not already in progress (i.e. a heartbeat timer using @CHA-T10@ as a timeout has not been defined):
 *** @(CHA-T4a1)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a2)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a3)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.started@, the format of which is detailed "here":#realtime-typing-heartbeat.
-*** @(CHA-T4a4)@ @[Testable]@ Upon successful publish, a timeout shall be set according to the @CHA-T10@ timeout interval.
+*** @(CHA-T4a4)@ @[Testable]@ Upon successful publish, a heartbeat timer shall be set according to the @CHA-T10@ timeout interval.
 ** @(CHA-T4b)@ This specification point has been removed. It was superseded by @CHA-T4c@.
-** @(CHA-T4c)@ If typing is already in progress (i.e. a @CHA-T10@ timeout has been defined):
+** @(CHA-T4c)@ If typing is already in progress (i.e. a heartbeat timer set according to @CHA-T4a4@ not expired yet):
 *** @(CHA-T4c1)@ @[Testable]@ The client must not send a @typing.started@ event.
 * @(CHA-T5)@ Users may explicitly indicate that they have stopped typing.
 ** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. no @CHA-T10@ timeout has been defined), this operation is no-op.
@@ -456,6 +456,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 *** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the subject from the typing set and emitting the updated set to any subscribers.
 *** @(CHA-T13b4)@ @[Testable]@ If the heartbeat represents a client that has stopped typing, then the chat client shall remove the typer from the typing set and emit the updated set to any subscribers. It shall also cancel the @(CHA-T13b1)@ timeout for the typing client.
 *** @(CHA-T13b5)@ @[Testable]@ If the heartbeat represents a client that has stopped typing, but the client is not known to be currently typing, the event is ignored.
+* @(CHA-T14)@ @[Testable]@ Handling multiple asynchronous calls to start/stop typing must converge to a consistent state. For example, a user begins typing, but publishing an event to the server takes some time, and the user calls @stop()@ typing before the first call completes. The client shall not send a @typing.stopped@ event and then a subsequent @typing.started@ event, it shall wait for the successful completion or failure of the first call before proceeding.
 * @(CHA-T7)@ @[Testable]@ Users may subscribe to discontinuity events to know when there's been a break in typing indicators. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For typing, there shouldn't need to be user action as the underlying core SDK will heal the presence set.
 
 h2(#occupancy). Occupancy

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -421,7 +421,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 
 * @(CHA-T1)@ This specification point has been removed. It was superseded by @CHA-T8@.
 * @(CHA-T2)@ This specification point has been removed. It was replaced by @CHA-T9@.
-* @(CHA-T8)@ Typing Indicators for a Room are exposed on the main rom channel, in the format @<roomId>::$chat@. For example, if your room id is @my-room@ then the channel will be @my-room::$chat@.
+* @(CHA-T8)@ Typing Indicators for a Room are exposed on the main room channel, in the format @<roomId>::$chat@. For example, if your room id is @my-room@ then the channel will be @my-room::$chat@.
 * @(CHA-T9)@ @[Testable]@ Users may retrieve a list of the currently typing client IDs.
 * @(CHA-T3)@ @[Testable]@ Users may configure a typing timeout interval (the time after which the client will assume the user has stopped typing). This configuration is provided at the @RoomOptions.typing.timeoutMs@ property, or idiomatic equivalent. The default value is unset.
 * @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the period between typing heartbeats sent by the client). This configuration is provided at the @RoomOptions.typing.heartbeatIntervalMs@ property, or idiomatic equivalent. The default is 15000ms.
@@ -463,6 +463,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 *** @(CHA-T13b2)@ @[Testable]@ Each additional typing heartbeat from the same client shall reset the @(CHA-T13b1)@ timeout.
 *** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the subject from the typing set and emitting the updated set to any subscribers.
 *** @(CHA-T13b4)@ @[Testable]@ If the heartbeat represents a client that has stopped typing, then the chat client shall remove the typer from the typing set and emit the updated set to any subscribers. It shall also cancel the @(CHA-T13b1)@ timeout for the typing client.
+*** @(CHA-T13b5)@ @[Testable]@ If the heartbeat represents a client that has stopped typing, but the client is not known to be currently typing, the event is ignored.
 * @(CHA-T7)@ @[Testable]@ Users may subscribe to discontinuity events to know when there's been a break in typing indicators. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For typing, there shouldn't need to be user action as the underlying core SDK will heal the presence set.
 
 h2(#occupancy). Occupancy

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -417,22 +417,23 @@ This system uses ephemeral non-persisted heartbeat messages. They do not appear 
 
 @Typing Indicators@ shall be exposed to consumers via the @typing@ property of a @Room@.
 
-For the purpose of this section, an @ephemeral message@ is understood to mean a regular message where @message.extras.ephemeral@ is set to @true@.
+For the purpose of this section, an @ephemeral message@ is understood to mean a regular message where @message.extras.ephemeral@ is set to @true@, i.e "typing-message-format":#realtime-typing-message.
 
 * @(CHA-T1)@ This specification point has been removed. It was superseded by @CHA-T8@.
 * @(CHA-T2)@ This specification point has been removed. It was replaced by @CHA-T9@.
 * @(CHA-T8)@ Typing Indicators for a Room are exposed on the main room channel, in the format @<roomId>::$chat@. For example, if your room id is @my-room@ then the channel will be @my-room::$chat@.
-* @(CHA-T9)@ @[Testable]@ Users may retrieve a list of the currently typing client IDs.
+* @(CHA-T9)@ @[Testable]@ Users must be able to retrieve a list of the currently typing client IDs through a @typing.get()@ method. The list must be a copy of the up-to-date internal list of typing client IDs.
+* @(CHA-T15)@ @[Testable]@ Users must be able to provide a listener to subscribe to new typing events that the Chat client emits. This operation must have no side effects on the status of the room or the underlying realtime channel.
 * @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the no-op period for @typing.keystroke@ when the heartbeat timer is set active at @CHA-T4a4@). This configuration is provided at the @RoomOptions.typing.heartbeatThrottleMs@ property, or idiomatic equivalent. The default is 10000ms.
-** @(CHA-T10a)@ @[Testable]@ A grace period shall be set by the client (the grace period on the @CHA-T10@ heartbeat interval when receiving heartbeats). The value shall be set to 2000ms.
-*** @(CHA-T10a1)@ @[Testable]@ If a @typing.start@ event is not received within this period, the client shall assume that the user has stopped typing. For example, if the client has not received a @typing.start@ event within 12000ms of the last heartbeat (10s heartbeat interval plus 2s grace period), the client shall assume that the user has stopped typing.
+** @(CHA-T10a)@ @[Testable]@ A grace period shall be set by the client (the grace period on the @CHA-T10@ heartbeat interval when receiving events). The value shall be set to 2000ms.
+*** @(CHA-T10a1)@ @[Testable]@ If a @typing.start@ event is not received within this period, the client shall assume that the user has stopped typing. For example, if the client has not received a @typing.start@ event within 12000ms of the last heartbeat (10s heartbeat interval plus 2s grace period), the client shall assume that the user has stopped typing and emit a @typing.stopped@ event for that user to all registered listeners @(CHA-T15)@.
 * @(CHA-T3)@ This specification point has been removed. It was replaced by @CHA-T10@.
 * @(CHA-T4)@ Users may indicate that they have started typing using the @keystroke@ method.
 ** @(CHA-T4d)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
-** @(CHA-T4a)@ If typing is not already in progress (i.e. a heartbeat timer not set on successful publish @CHA-T4a4@):
+** @(CHA-T4a)@ If typing is not already in progress (i.e. a heartbeat timer has not been set by the successful publish @CHA-T4a4@ of a @typing.started@ event):
 *** @(CHA-T4a1)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a2)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
-*** @(CHA-T4a3)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.started@, the format of which is detailed "here":#realtime-typing-heartbeat.
+*** @(CHA-T4a3)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the @name@ field set to @typing.started@, the format of which is detailed "here":#realtime-typing-message.
 *** @(CHA-T4a4)@ @[Testable]@ Upon successful publish, a heartbeat timer shall be set according to the @CHA-T10@ timeout interval.
 ** @(CHA-T4b)@ This specification point has been removed. It was superseded by @CHA-T4c@.
 ** @(CHA-T4c)@ If typing is already in progress (i.e. a heartbeat timer set according to @CHA-T4a4@ exists and has not expired):
@@ -441,7 +442,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 ** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. a @CHA-T10@ heartbeat timer does not exist or is expired), this operation is a no-op.
 ** @(CHA-T5b)@ This specification point has been removed.
 ** @(CHA-T5c)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
-** @(CHA-T5d)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-heartbeat.
+** @(CHA-T5d)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-message.
 ** @(CHA-T5e)@ @[Testable]@ On successfully publishing the message in @(CHA-T5d)@, the @CHA-T10@ timer shall be unset.
 * @(CHA-T6)@ Users may subscribe to typing events - updates to a set of clientIDs that are typing. This operation, like all subscription operations, has no side-effects in relation to room lifecycle.
 ** @(CHA-T6a)@ @[Testable]@ Users may provide a listener to subscribe to "typing event V2":#chat-structs-typing-event-V2 in a chat room.
@@ -449,14 +450,14 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 ** @(CHA-T6c)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
 *** @(CHA-T6c1)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
 *** @(CHA-T6c2)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
-* @(CHA-T13)@ When a typing event (@typing.start@ or @typing.stop@) is received from the realtime client, the Chat client shall emit appropriate events to the user.
-** @(CHA-T13a)@ @[Testable]@ If the typing event received from the server is malformed, i.e does not conform to the expected "payload":#realtime-typing-events (unknown fields should be ignored), then it shall not be handled and emitted to the subscriber.
-** @(CHA-T13b)@ @[Testable]@ When a typing event is received from the realtime client:
-*** @(CHA-T13b1)@ @[Testable]@ If the event represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ graсe period.
-*** @(CHA-T13b2)@ @[Testable]@ Each additional typing heartbeat from the same client shall reset the @(CHA-T13b1)@ timeout.
-*** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the clientId from the typing set and emit a synthetic typing stop event for the given client.
-*** @(CHA-T13b4)@ @[Testable]@ If the event represents a client that has stopped typing, then the chat client shall remove the clientId from the typing set and emit the updated set to any subscribers. It shall also cancel the @(CHA-T13b1)@ timeout for the typing client.
-*** @(CHA-T13b5)@ @[Testable]@ If the event represents that a client has stopped typing, but the clientId for that client is not present in the typing set, then the event is ignored.
+* @(CHA-T13)@ When a typing event (@typing.start@ or @typing.stop@) is received from the realtime client, the Chat client shall emit appropriate events to all registered listeners @(CHA-T15)@.
+** @(CHA-T13a)@ @[Testable]@ If the typing event received from the server is malformed, i.e does not conform to the expected "payload":#realtime-typing-message (unknown fields should be ignored), then it shall not be handled and emitted to the subscriber.
+** @(CHA-T13b)@ @[Testable]@ When a typing event is received on the realtime client:
+*** @(CHA-T13b1)@ @[Testable]@ If the event represents a new client typing, then the Chat client shall add the typers clientId (@msg.clientId@) to the typing set and a emit the updated set, via a new "typing event":#chat-structs-typing-event-V2 , to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ graсe period.
+*** @(CHA-T13b2)@ @[Testable]@ Each additional @typing.started@ event from the same client shall reset the @(CHA-T13b1)@ timeout for that client.
+*** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the clientId from the typing set and emit a typing stop event for the given client to all registered listeners (@(CHA-T15)@).
+*** @(CHA-T13b4)@ @[Testable]@ If the event represents a client that has stopped typing, the Chat client shall remove the clientId from the typing set and emit the updated set to any registered listeners (@(CHA-T15)@). It shall also cancel the @(CHA-T13b1)@ timeout for that typer.
+*** @(CHA-T13b5)@ @[Testable]@ If the event represents a client that has stopped typing, but the clientId for that client is not present in the typing set, then no event shall be emitted to any registered listeners (@(CHA-T15)@).
 * @(CHA-T14)@ @[Testable]@ Multiple asynchronous calls to keystroke/stop typing must eventually converge to a consistent state.
 ** @(CHA-TM14a)@ When a call to @keystroke@ or @stop@ is made, it should attempt to acquire a mutex lock.
 ** @(CHA-TM14b)@ Once the lock is acquired, if another call is made to either function, the second call shall be queued and wait until it can acquire the lock before executing.
@@ -797,15 +798,13 @@ h3(#realtime-room-reactions). Ephemeral Room Reactions
   }
 </pre>
 
-h3(#realtime-typing-events). Typing Events
+h3(#realtime-typing-message). Typing Message
 
 <pre>
   {
-    "name": "typing.started" | "typing.stopped"
-    "encoding": "json"
-    "clientId": "who-is-typing",
-    "timestamp": "1726232498871", // Only on incoming messages
-    "extras": { "ephemeral": true}
+    "name": "typing.started" // Required, must be either "typing.started" or "typing.stopped"
+    "clientId": "who-is-typing", // Required, cannot be empty string or null
+    "extras": { "ephemeral": true } // Required, must be set to true
   }
 </pre>
 
@@ -974,7 +973,7 @@ h3(#chat-structs-typing-event-V2). Typing Event V2
         "type": "typing.started",
         "clientId": "clientId-2",
     },
-    "currentlyTyping": ["clientId-1", "clientID-2"],
+    "currentlyTyping": ["clientId-1", "clientId-2"],
   }
 </pre>
 

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -423,12 +423,12 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 * @(CHA-T2)@ This specification point has been removed. It was replaced by @CHA-T9@.
 * @(CHA-T8)@ Typing Indicators for a Room are exposed on the main room channel, in the format @<roomId>::$chat@. For example, if your room id is @my-room@ then the channel will be @my-room::$chat@.
 * @(CHA-T9)@ @[Testable]@ Users may retrieve a list of the currently typing client IDs.
-* @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the period between typing heartbeats sent by the client). This configuration is provided at the @RoomOptions.typing.heartbeatThrottleMs@ property, or idiomatic equivalent. The default is 10000ms.
+* @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the no-op period for @typing.keystroke@ when the heartbeat timer is set active at @CHA-T4a4@). This configuration is provided at the @RoomOptions.typing.heartbeatThrottleMs@ property, or idiomatic equivalent. The default is 10000ms.
 ** @(CHA-T10a)@ @[Testable]@ A grace period shall be set by the client (the grace period on the @CHA-T10@ heartbeat interval when receiving heartbeats). The value shall be set to 2000ms.
-*** @(CHA-T10a1)@ @[Testable]@ If a heartbeat is not received within this period, the client shall assume that the user has stopped typing. For example, if the client has not received a heartbeat within 12000ms of the last heartbeat (10s heartbeat interval plus 2s grace period), the client shall assume that the user has stopped typing.
-* @(CHA-T4)@ Users may indicate that they have started typing.
+*** @(CHA-T10a1)@ @[Testable]@ If a @typing.start@ event is not received within this period, the client shall assume that the user has stopped typing. For example, if the client has not received a @typing.start@ event within 12000ms of the last heartbeat (10s heartbeat interval plus 2s grace period), the client shall assume that the user has stopped typing.
+* @(CHA-T4)@ Users may indicate that they have started typing using the @keystroke@ method.
 ** @(CHA-T4d)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
-** @(CHA-T4a)@ If typing is not already in progress (i.e. a heartbeat timer using @CHA-T10@ as a timeout has not been defined):
+** @(CHA-T4a)@ If typing is not already in progress (i.e. a heartbeat timer not set on successful publish @CHA-T4a4@):
 *** @(CHA-T4a1)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a2)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a3)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.started@, the format of which is detailed "here":#realtime-typing-heartbeat.
@@ -436,8 +436,8 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 ** @(CHA-T4b)@ This specification point has been removed. It was superseded by @CHA-T4c@.
 ** @(CHA-T4c)@ If typing is already in progress (i.e. a heartbeat timer set according to @CHA-T4a4@ not expired yet):
 *** @(CHA-T4c1)@ @[Testable]@ The client must not send a @typing.started@ event.
-* @(CHA-T5)@ Users may explicitly indicate that they have stopped typing.
-** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. no @CHA-T10@ timeout has been defined), this operation is no-op.
+* @(CHA-T5)@ Users may explicitly indicate that they have stopped typing using @stop@ method.
+** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. heartbeat timer using @CHA-T10@ as a timeout is not active), this operation is a no-op.
 ** @(CHA-T5b)@ This specification point has been removed.
 ** @(CHA-T5c)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
 ** @(CHA-T5d)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-heartbeat.
@@ -448,14 +448,14 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 ** @(CHA-T6c)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
 *** @(CHA-T6c1)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
 *** @(CHA-T6c2)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
-* @(CHA-T13)@ When a typing heartbeat is received from the realtime client, the Chat client shall emit appropriate events to the user.
-** @(CHA-T13a)@ @[Testable]@ If the typing heartbeat is malformed (unknown fields should be ignored), then it shall not be emitted to the subscriber.
-** @(CHA-T13b)@ @[Testable]@ When a typing heartbeat is received from the realtime client;
-*** @(CHA-T13b1)@ @[Testable]@ If the heartbeat represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ grade period.
+* @(CHA-T13)@ When a typing event (@typing.start@ or @typing.stop@) is received from the realtime client, the Chat client shall emit appropriate events to the user.
+** @(CHA-T13a)@ @[Testable]@ If the typing event is malformed (unknown fields should be ignored), then it shall not be emitted to the subscriber.
+** @(CHA-T13b)@ @[Testable]@ When a typing event is received from the realtime client;
+*** @(CHA-T13b1)@ @[Testable]@ If the event represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ grade period.
 *** @(CHA-T13b2)@ @[Testable]@ Each additional typing heartbeat from the same client shall reset the @(CHA-T13b1)@ timeout.
-*** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the subject from the typing set and emitting the updated set to any subscribers.
-*** @(CHA-T13b4)@ @[Testable]@ If the heartbeat represents a client that has stopped typing, then the chat client shall remove the typer from the typing set and emit the updated set to any subscribers. It shall also cancel the @(CHA-T13b1)@ timeout for the typing client.
-*** @(CHA-T13b5)@ @[Testable]@ If the heartbeat represents a client that has stopped typing, but the client is not known to be currently typing, the event is ignored.
+*** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the clientId from the typing set and emit typing stop event for the given client with an updated set.
+*** @(CHA-T13b4)@ @[Testable]@ If the event represents a client that has stopped typing, then the chat client shall remove the clientId from the typing set and emit the updated set to any subscribers. It shall also cancel the @(CHA-T13b1)@ timeout for the typing client.
+*** @(CHA-T13b5)@ @[Testable]@ If the event represents that a client has stopped typing, but the clientId for that client is not present in the typing set, then the event is ignored.
 * @(CHA-T14)@ @[Testable]@ Handling multiple asynchronous calls to start/stop typing must converge to a consistent state. For example, a user begins typing, but publishing an event to the server takes some time, and the user calls @stop()@ typing before the first call completes. The client shall not send a @typing.stopped@ event and then a subsequent @typing.started@ event, it shall wait for the successful completion or failure of the first call before proceeding.
 * @(CHA-T7)@ @[Testable]@ Users may subscribe to discontinuity events to know when there's been a break in typing indicators. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For typing, there shouldn't need to be user action as the underlying core SDK will heal the presence set.
 
@@ -800,9 +800,9 @@ h3(#realtime-typing-events). Typing Events
   {
     "name": "typing.started" | "typing.stopped"
     "encoding": "json"
-    "data": nil
+    "clientId": "who-is-typing",
     "timestamp": "1726232498871", // Only on incoming messages
-    "extras": {}
+    "extras": { "ephemeral": true}
   }
 </pre>
 
@@ -968,7 +968,7 @@ h3(#chat-structs-typing-event-V2). Typing Event V2
 <pre>
   {
     "change": {
-        "event": "typing.started",
+        "type": "typing.started",
         "clientId": "clientId-2",
     },
     "currentlyTyping": ["clientId-1", "clientID-2"],

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -426,7 +426,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 * @(CHA-T15)@ @[Testable]@ Users must be able to provide a listener to subscribe to new typing events that the Chat client emits. This operation must have no side effects on the status of the room or the underlying realtime channel.
 * @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the no-op period for @typing.keystroke@ when the heartbeat timer is set active at @CHA-T4a4@). This configuration is provided at the @RoomOptions.typing.heartbeatThrottleMs@ property, or idiomatic equivalent. The default is 10000ms.
 ** @(CHA-T10a)@ A grace period shall be set by the client (the grace period on the @CHA-T10@ heartbeat interval when receiving events). The default value shall be set to 2000ms.
-*** @(CHA-T10a1)@ This grace period is used to determine how long to wait, beyond the heartbeat interval, before removing a client from the typing set. This is used to prevent flickering when a user is typing and stops typing for a short period of time. See @CHA-T13b1@ for a detailed description of how this is used.
+*** @(CHA-T10a1)@ This grace period is used to determine how long to wait (since the last recorded received typing event), beyond the heartbeat interval, before removing a client from the typing set. This is used to prevent flickering when a user is typing and stops typing for a short period of time. See @CHA-T13b1@ for a detailed description of how this is used.
 * @(CHA-T3)@ This specification point has been removed. It was replaced by @CHA-T10@.
 * @(CHA-T4)@ Users may indicate that they have started typing using the @keystroke@ method.
 ** @(CHA-T4d)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
@@ -435,7 +435,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 *** @(CHA-T4a2)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a3)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the @name@ field set to @typing.started@, the format of which is detailed "here":#realtime-typing-message.
 *** @(CHA-T4a4)@ @[Testable]@ Upon successful publish, a heartbeat timer shall be set according to the @CHA-T10@ timeout interval.
-*** @(CHA-T4a5)@ @[Testable]@ The client must wait for the publish to succeed or fail before returning the result to the caller. If the publish fails, the client must throw an @ErrorInfo@.
+*** @(CHA-T4a5)@ @[Testable]@ The client must wait for the publish to succeed or fail before returning the result to the caller. If the publish fails, the client must handle this transparently and re-throw the error directly to the caller.
 ** @(CHA-T4b)@ This specification point has been removed. It was superseded by @CHA-T4c@.
 ** @(CHA-T4c)@ If typing is already in progress (i.e. a heartbeat timer set according to @CHA-T4a4@ exists and has not expired):
 *** @(CHA-T4c1)@ @[Testable]@ The client must not send a @typing.started@ event, instead it shall return a successful no-op to the caller.
@@ -444,7 +444,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 ** @(CHA-T5b)@ This specification point has been removed.
 ** @(CHA-T5c)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
 ** @(CHA-T5d)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-message. The client must wait for the publish to succeed or fail before returning the result to the caller.
-** @(CHA-T5d1)@ @[Testable]@ The client must wait for the publish to succeed or fail before returning the result to the caller. If the publish fails, the client must throw an @ErrorInfo@.
+** @(CHA-T5d1)@ @[Testable]@ The client must wait for the publish to succeed or fail before returning the result to the caller. If the publish fails, the client must handle this transparently and re-throw the error directly to the caller.
 ** @(CHA-T5e)@ @[Testable]@ On successfully publishing the message in @(CHA-T5d)@, the @CHA-T10@ timer shall be unset.
 * @(CHA-T6)@ Users may subscribe to typing events - updates to a set of clientIDs that are typing. This operation, like all subscription operations, has no side-effects in relation to room lifecycle.
 ** @(CHA-T6a)@ @[Testable]@ Users may provide a listener to subscribe to "typing event V2":#chat-structs-typing-event-V2 in a chat room.
@@ -458,7 +458,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 *** @(CHA-T13b1)@ @[Testable]@ If the event represents a new client typing, then the Chat client shall add the typers @clientId@ to the typing set and a emit the updated set, via a new "typing event":#chat-structs-typing-event-V2 , to any listeners. It shall also begin a timer with a timeout period that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ graсe period.
 *** @(CHA-T13b2)@ @[Testable]@ Each additional @typing.started@ event from the same client shall reset the @(CHA-T13b1)@ timer for that client.
 *** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timer expires, the client shall remove the @clientId@ from the typing set and emit a typing stopped event for the given client to all registered listeners (@CHA-T15@).
-*** @(CHA-T13b4)@ @[Testable]@ If the event represents a client that has stopped typing, the Chat client shall remove the @clientId@ from the typing set and emit a typing stopped event to any registered listeners (@CHA-T15@). It shall also cancel the @(CHA-T13b1)@ timer for that the given typing client.
+*** @(CHA-T13b4)@ @[Testable]@ If the event represents a client that has stopped typing, the Chat client shall remove the @clientId@ from the typing set and emit a typing stopped event to any registered listeners (@CHA-T15@). It shall also cancel the @(CHA-T13b1)@ timer for the given typing client.
 *** @(CHA-T13b5)@ @[Testable]@ If the event represents a client that has stopped typing, but the @clientId@ for that client is not present in the typing set, then no stop typing event shall be emitted to any registered listeners (@CHA-T15@).
 * @(CHA-T14)@ @[Testable]@ Multiple asynchronous calls to keystroke/stop typing must eventually converge to a consistent state.
 ** @(CHA-TM14a)@ @[Testable]@ When a call to @keystroke@ or @stop@ is made, it should attempt to acquire a mutex lock.

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -435,10 +435,10 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 *** @(CHA-T4a3)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.started@, the format of which is detailed "here":#realtime-typing-heartbeat.
 *** @(CHA-T4a4)@ @[Testable]@ Upon successful publish, a heartbeat timer shall be set according to the @CHA-T10@ timeout interval.
 ** @(CHA-T4b)@ This specification point has been removed. It was superseded by @CHA-T4c@.
-** @(CHA-T4c)@ If typing is already in progress (i.e. a heartbeat timer set according to @CHA-T4a4@ not expired yet):
+** @(CHA-T4c)@ If typing is already in progress (i.e. a heartbeat timer set according to @CHA-T4a4@ exists and has not expired):
 *** @(CHA-T4c1)@ @[Testable]@ The client must not send a @typing.started@ event.
 * @(CHA-T5)@ Users may explicitly indicate that they have stopped typing using @stop@ method.
-** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. heartbeat timer using @CHA-T10@ as a timeout is not active), this operation is a no-op.
+** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. a @CHA-T10@ heartbeat timer exists and has not expired), this operation is a no-op.
 ** @(CHA-T5b)@ This specification point has been removed.
 ** @(CHA-T5c)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
 ** @(CHA-T5d)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-heartbeat.
@@ -451,14 +451,16 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 *** @(CHA-T6c2)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
 * @(CHA-T13)@ When a typing event (@typing.start@ or @typing.stop@) is received from the realtime client, the Chat client shall emit appropriate events to the user.
 ** @(CHA-T13a)@ @[Testable]@ If the typing event is malformed (unknown fields should be ignored), then it shall not be emitted to the subscriber.
-** @(CHA-T13b)@ @[Testable]@ When a typing event is received from the realtime client;
+** @(CHA-T13b)@ @[Testable]@ When a typing event is received from the realtime client:
 *** @(CHA-T13b1)@ @[Testable]@ If the event represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ graсe period.
 *** @(CHA-T13b2)@ @[Testable]@ Each additional typing heartbeat from the same client shall reset the @(CHA-T13b1)@ timeout.
-*** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the clientId from the typing set and emit typing stop event for the given client with an updated set.
+*** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the clientId from the typing set and emit a synthetic typing stop event for the given client.
 *** @(CHA-T13b4)@ @[Testable]@ If the event represents a client that has stopped typing, then the chat client shall remove the clientId from the typing set and emit the updated set to any subscribers. It shall also cancel the @(CHA-T13b1)@ timeout for the typing client.
 *** @(CHA-T13b5)@ @[Testable]@ If the event represents that a client has stopped typing, but the clientId for that client is not present in the typing set, then the event is ignored.
-* @(CHA-T14)@ @[Testable]@ Handling multiple asynchronous calls to start/stop typing must converge to a consistent state. For example, a user begins typing, but publishing an event to the server takes some time, and the user calls @stop()@ typing before the first call completes. The client shall not send a @typing.stopped@ event and then a subsequent @typing.started@ event, it shall wait for the successful completion or failure of the first call before proceeding.
-* @(CHA-T7)@ @[Testable]@ Users may subscribe to discontinuity events to know when there's been a break in typing indicators. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For typing, there shouldn't need to be user action as the underlying core SDK will heal the presence set.
+* @(CHA-T14)@ @[Testable]@ Multiple asynchronous calls to keystroke/stop typing must eventually converge to a consistent state.
+** @(CHA-TM14a)@ When a call to @keystroke@ or @stop@ is made, it should attempt to acquire a mutex lock.
+** @(CHA-TM14b)@ Once the lock is acquired, if another call is made to either function, the second call shall be queued and wait until it can acquire the lock before executing.
+*** @(CHA-TM14b1)@ During this time, each new subsequent call to either function shall abort the previously queued call. In doing so, there shall only ever be one pending call and while the mutex is held, thus the most recent call shall "win" and execute once the mutex is released.
 
 h2(#occupancy). Occupancy
 

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -452,7 +452,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 * @(CHA-T13)@ When a typing event (@typing.start@ or @typing.stop@) is received from the realtime client, the Chat client shall emit appropriate events to the user.
 ** @(CHA-T13a)@ @[Testable]@ If the typing event is malformed (unknown fields should be ignored), then it shall not be emitted to the subscriber.
 ** @(CHA-T13b)@ @[Testable]@ When a typing event is received from the realtime client;
-*** @(CHA-T13b1)@ @[Testable]@ If the event represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ grade period.
+*** @(CHA-T13b1)@ @[Testable]@ If the event represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T10a@ graсe period.
 *** @(CHA-T13b2)@ @[Testable]@ Each additional typing heartbeat from the same client shall reset the @(CHA-T13b1)@ timeout.
 *** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the clientId from the typing set and emit typing stop event for the given client with an updated set.
 *** @(CHA-T13b4)@ @[Testable]@ If the event represents a client that has stopped typing, then the chat client shall remove the clientId from the typing set and emit the updated set to any subscribers. It shall also cancel the @(CHA-T13b1)@ timeout for the typing client.

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -411,35 +411,57 @@ Presence allows chat room users to indicate to others that they're online, as we
 
 h2(#typing). Typing Indicators
 
-Typing Indicators allow chat room users to indicate to others that they are typing. This is most common in 1:1 and community chat, where the client would display "Alice and Bob are typing..." to users. This system is presence-based, to avoid the cost of heartbeat/polling messages, with entering presence deemed to mean "started typing" and leaving presence deemed to mean "stopped typing".
+Typing Indicators allow chat room users to indicate to others that they are typing. This is most common in 1:1 and community chat, where the client would display "Alice and Bob are typing..." to users.
+@(deprecated)@ This system is presence-based, to avoid the cost of heartbeat/polling messages, with entering presence deemed to mean "started typing" and leaving presence deemed to mean "stopped typing".
+
+This system uses heartbeat messages, alongside specific message metadata (TBD) which disables persistence for them, reducing the cost of servicing the heartbeats.
 
 @Typing Indicators@ shall be exposed to consumers via the @typing@ property of a @Room@.
 
-* @(CHA-T1)@ Typing Indicators for a Room is exposed on a dedicated Realtime channel. These channels use the format @<roomId>::$chat::$typingIndicators@. For example, if your room id is @my-room@ then the typing channel will be @my-room::$chat::$typingIndicators@.
-* @(CHA-T2)@ @[Testable]@ Users may retrieve a list of the currently typing client IDs. The behaviour depends on the current room status, as presence operations in a Realtime Client cause implicit attaches.
+* @(CHA-T1)@ @(deprecated)@ Typing Indicators for a Room is exposed on a dedicated Realtime channel. These channels use the format @<roomId>::$chat::$typingIndicators@. For example, if your room id is @my-room@ then the typing channel will be @my-room::$chat::$typingIndicators@.
+* @(CHA-T2)@ @(deprecated)@ @[Testable]@ Users may retrieve a list of the currently typing client IDs. The behaviour depends on the current room status, as presence operations in a Realtime Client cause implicit attaches.
+* @(CHA-T8)@ Typing Indicators for a Room is exposed on the channel used for chat messages, in the format @<roomId>::$chat::$chatMessages@. For example, if your room id is @my-room@ then the presence channel will be @my-room::$chat::$chatMessages@.
+* @(CHA-T9)@ @[Testable]@ Users may retrieve a list of the currently typing client IDs.
 ** @(CHA-T2b)@ This specification point has been removed.
 *** @(CHA-T2b1)@ This specification point has been removed.
 *** @(CHA-T2b2)@ This specification point has been removed.
-** @(CHA-T2c)@ @[Testable]@ If the room status is @Attaching@, then the operation shall invoke a @CHA-RL9@ pending room status operation and wait for it to complete. If this operation fails, then the error from @CHA-RL9@ must be raised. If this succeeds (i.e the room becomes @ATTACHED@), the library must invoke the underlying @presence.get()@ call.
-** @(CHA-T2g)@ @[Testable]@ If the room status is anything other than @Attached@ or @Attaching@, an @ErrorInfo@ using the @RoomInInvalidState@ error code from the "chat-specific error codes":#error-codes with a status code of @400@ must be thrown. The message shall explain that attach must be called first.
-** @(CHA-T2d)@ @[Testable]@ If the room status is @Attached@, then the @get@ call shall invoke the underlying @presence.enter()@ call.
+** @(CHA-T2c)@ @(deprecated)@ @[Testable]@ If the room status is @Attaching@, then the operation shall invoke a @CHA-RL9@ pending room status operation and wait for it to complete. If this operation fails, then the error from @CHA-RL9@ must be raised. If this succeeds (i.e the room becomes @ATTACHED@), the library must invoke the underlying @presence.get()@ call.
+** @(CHA-T2g)@ @(deprecated)@ @[Testable]@ If the room status is anything other than @Attached@ or @Attaching@, an @ErrorInfo@ using the @RoomInInvalidState@ error code from the "chat-specific error codes":#error-codes with a status code of @400@ must be thrown. The message shall explain that attach must be called first.
+** @(CHA-T2d)@ @(deprecated)@ @[Testable]@ If the room status is @Attached@, then the @get@ call shall invoke the underlying @presence.enter()@ call.
+
 ** @(CHA-T2e)@ This specification point has been removed. It was superseded by @CHA-T2g@.
 ** @(CHA-T2f)@ This specification point has been removed. It was superseded by @CHA-T2g@.
 * @(CHA-T3)@ @[Testable]@ Users may configure a timeout interval for when they are typing. This configuration is provided as part of the @RoomOptions@ @typing.timeoutMs@ property, or idiomatic equivalent. The default is 5000ms.
+* @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval for when they are typing. This configuration is provided as part of the @RoomOptions@ @typing.heartbeatIntervalMs@ property, or idiomatic equivalent. The default is 15000ms.
+* @(CHA-T11)@ @[Testable]@ Users may configure an inactivity timeout interval for when they are receiving heartbeats from other users. This configuration is provided as part of the @RoomOptions@ @typing.inactivityTimeoutMs@ property, or idiomatic equivalent. The default is 2000ms.
 * @(CHA-T4)@ Users may indicate that they have started typing.
 ** @(CHA-T4a)@ @[Testable]@ If typing is not already in progress, per explicit cancellation or the timeout interval in (@CHA-T3@), then a new typing session is started.
-*** @(CHA-T4a1)@ @[Testable]@ When a typing session is started, the client is entered into presence on the typing channel.
-*** @(CHA-T4a2)@ @[Testable]@ When a typing session is started, a timeout is set according to the @CHA-T3@ timeout interval. When this timeout expires, the typing session is automatically ended by leaving presence.
+*** @(CHA-T4a1)@ @(deprecated)@ @[Testable]@ When a typing session is started, the client is entered into presence on the typing channel.
+*** @(CHA-T4a2)@ @(deprecated)@ @[Testable]@ When a typing session is started, a timeout is set according to the @CHA-T3@ timeout interval. When this timeout expires, the typing session is automatically ended by leaving presence.
+
+*** @(CHA-T4a3)@ @[Testable]@ When a typing session is started, the client shall publish a heartbeat message with the name field set to `typing.started`, the format of which is detailed "here":#realtime-typing-heartbeat.
+*** @(CHA-T4a4)@ @[Testable]@ When a typing session is started, a timeout shall be set according to the @CHA-T3@ timeout interval, if the interval is undefined, no timout shall be set. When this timeout expires, the client shall publish a heartbeat message with the name field set to `typing.stopped`, the format of which is detailed "here":#realtime-typing-heartbeat.
+*** @(CHA-T4a5)@ @[Testable]@ When a typing session is started, a timeout shall be set according to the @CHA-T10@ timeout interval. Until this timeout expires, the client shall not publish any further `typing.started` "heartbeats":#realtime-typing-heartbeat.
+
 ** @(CHA-T4b)@ @[Testable]@ If typing is already in progress, the @CHA-T3@ timeout is extended to be @timeoutMs@ from now.
+** @(CHA-T4c)@ @[Testable]@ If typing is already in progress, the client shall not publish any further `typing.started` heartbeats until the @CHA-T10@ timeout expires. After expiration, if the client is still typing, it shall publish a `typing.started` "heartbeat":#realtime-typing-heartbeat and restart the @CHA-T10@ timeout.
+
 * @(CHA-T5)@ Users may indicate that they have stopped typing.
 ** @(CHA-T5a)@ @[Testable]@ If typing is not in progress, this operation is no-op.
-** @(CHA-T5b)@ @[Testable]@ If typing is in progress, he @CHA-T3@ timeout is cancelled. The client then leaves presence.
+** @(CHA-T5b)@ @(deprecated)@ @[Testable]@ If typing is in progress, the @CHA-T3@ timeout is cancelled. The client then leaves presence.
+** @(CHA-T5b)@ @(deprecated)@ @[Testable]@ If typing is in progress, the @CHA-T3@ and @CHA-T10@ timeouts shall be cancelled, and the client shall publish a heartbeat message with the name field set to `typing.stopped`.
 * @(CHA-T6)@ Users may subscribe to typing events - updates to a set of clientIDs that are typing. This operation, like all subscription operations, has no side-effects in relation to room lifecycle.
-** @(CHA-T6a)@ @[Testable]@ Users may provide a listener to subscribe to "typing events":#chat-structs-typing-event in a room.
+** @(CHA-T6a)@ @[Testable]@ Users may provide a listener to subscribe to "typing event V1":#chat-structs-typing-event in a room. Note, "typing event V1":#chat-structs-typing-event is a deprecated, please use "typing event V2":#chat-structs-typing-event-V2.
 ** @(CHA-T6b)@ @[Testable]@ A subscription to typing may be removed, after which it shall receive no further events.
-** @(CHA-T6c)@ @[Testable]@ When a presence event is received from the realtime client, the Chat client will perform a @presence.get()@ operation to get the current presence set. This guarantees that we get a fully synced presence set. This is then used to emit the typing clients to the subscriber.
-*** @(CHA-T6c1)@ @[Testable]@ If the @presence.get()@ operation fails, then it shall be retried using a backoff with jitter, up to a timeout of 30 seconds.
-*** @(CHA-T6c2)@ @[Testable]@ If multiple presence events are received resulting in concurrent @presence.get()@ calls, then we guarantee that only the "latest" event is emitted. That is to say, if presence event A and B occur in that order, then only the typing event generated by B's call to @presence.get()@ will be emitted to typing subscribers.
+** @(CHA-T6c)@ @(deprecated)@ @[Testable]@ When a presence event is received from the realtime client, the Chat client will perform a @presence.get()@ operation to get the current presence set. This guarantees that we get a fully synced presence set. This is then used to emit the typing clients to the subscriber.
+*** @(CHA-T6c1)@ @(deprecated)@ @[Testable]@ If the @presence.get()@ operation fails, then it shall be retried using a backoff with jitter, up to a timeout of 30 seconds.
+*** @(CHA-T6c2)@ @(deprecated)@ @[Testable]@ If multiple presence events are received resulting in concurrent @presence.get()@ calls, then we guarantee that only the "latest" event is emitted. That is to say, if presence event A and B occur in that order, then only the typing event generated by B's call to @presence.get()@ will be emitted to typing subscribers.
+** @(CHA-T6d) @[Testable]@ When a typing heartbeat is received from the realtime client, the Chat client shall emit the updated set of typing clients to the subscriber, along with the clientId of the client that started/stopped typing.
+** @(CHA-T6d1) @[Testable]@ If the typing heartbeat is malformed (unknown fields should be ignored), then it shall not be emitted to the subscriber.
+** @(CHA-T6d2) @[Testable]@ When a typing heartbeat is received from the realtime client;
+*** @(CHA-T6d2a) @[Testable]@ If the heartbeat represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a @(CHA-T10)@ timeout for the typing client.
+*** @(CHA-T6d2b) @[Testable]@ Each additional typing heartbeat from the same client shall reset the @(CHA-T10)@ timeout for the typing client. If the timeout expires, the client shall wait for a further @(CHA-T11)@ time before removing the client from the typing set and emitting the updated set to any subscribers.
+*** @(CHA-T6d2c) @[Testable]@ If the heartbeat represents a client that has stopped typing, then the chat client shall remove the typer from the typing set and emit the updated set to any subscribers. It shall also cancel the @(CHA-T10)@ timeout for the typing client.
 * @(CHA-T7)@ @[Testable]@ Users may subscribe to discontinuity events to know when there's been a break in typing indicators. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For typing, there shouldn't need to be user action as the underlying core SDK will heal the presence set.
 
 h2(#occupancy). Occupancy
@@ -777,6 +799,19 @@ h3(#realtime-room-reactions). Ephemeral Room Reactions
   }
 </pre>
 
+h3(#realtime-typing-heartbeats). Typing Heartbeats
+
+<pre>
+  {
+    "name": "typing.started" | "typing.stopped"
+    "encoding": "json"
+    "data": {}
+    },
+    "timestamp": "1726232498871", // Only on incoming messages
+    "extras": {}
+  }
+</pre>
+
 h3(#rest-occupancy). Occupancy
 
 h4(#rest-occupancy-request). Request
@@ -926,10 +961,20 @@ h3(#chat-structs-presence-event). Presence Event
   }
 </pre>
 
-h3(#chat-structs-typing-event). Typing Event
+h3(#chat-structs-typing-event). Typing Event @(deprecated)@
 
 <pre>
   {
+    "currentlyTyping": ["clientId-1", "clientID-2"],
+  }
+</pre>
+
+h3(#chat-structs-typing-event-V2). Typing Event V2
+
+<pre>
+  {
+    "event": "typing.started" | "typing.stopped",
+    "clientId": "clientId-2",
     "currentlyTyping": ["clientId-1", "clientID-2"],
   }
 </pre>

--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -423,17 +423,17 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 * @(CHA-T2)@ This specification point has been removed. It was replaced by @CHA-T9@.
 * @(CHA-T8)@ Typing Indicators for a Room are exposed on the main rom channel, in the format @<roomId>::$chat@. For example, if your room id is @my-room@ then the channel will be @my-room::$chat@.
 * @(CHA-T9)@ @[Testable]@ Users may retrieve a list of the currently typing client IDs.
-* @(CHA-T3)@ @[Testable]@ Users may configure a typing timeout interval (the time after which the client will assume the user has stopped typing). This configuration is provided as part of the @RoomOptions@ @typing.timeoutMs@ property, or idiomatic equivalent. The default value is unset.
-* @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the period between typing heartbeats sent by the client). This configuration is provided as part of the @RoomOptions@ @typing.heartbeatIntervalMs@ property, or idiomatic equivalent. The default is 15000ms.
-* @(CHA-T11)@ @[Testable]@ Users may configure an inactivity timeout interval (the grace period on the @CHA-T10@ heartbeat interval when receiving heartbeats). This configuration is provided as part of the @RoomOptions@ @typing.inactivityTimeoutMs@ property, or idiomatic equivalent. The default is 2000ms.
+* @(CHA-T3)@ @[Testable]@ Users may configure a typing timeout interval (the time after which the client will assume the user has stopped typing). This configuration is provided at the @RoomOptions.typing.timeoutMs@ property, or idiomatic equivalent. The default value is unset.
+* @(CHA-T10)@ @[Testable]@ Users may configure a heartbeat interval (the period between typing heartbeats sent by the client). This configuration is provided at the @RoomOptions.typing.heartbeatIntervalMs@ property, or idiomatic equivalent. The default is 15000ms.
+* @(CHA-T11)@ @[Testable]@ Users may configure an inactivity timeout interval (the grace period on the @CHA-T10@ heartbeat interval when receiving heartbeats). This configuration is provided as part of the @RoomOptions@ @typing.inactivityTimeoutMs@ property, or idiomatic equivalent. The default is 500ms.
 * @(CHA-T4)@ Users may indicate that they have started typing.
 ** @(CHA-T4d)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
 ** @(CHA-T4a)@ If typing is not already in progress (i.e. a @CHA-T10@ timeout has not been defined):
 *** @(CHA-T4a1)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a2)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a3)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.started@, the format of which is detailed "here":#realtime-typing-heartbeat.
-*** @(CHA-T4a4)@ @[Testable]@ Upon successful publish, a timeout shall be set according to the @CHA-T3@ timeout interval, if the interval is undefined, no timeout shall be set. When this timeout expires, the client shall publish a heartbeat message with the name field set to `typing.stopped`, the format of which is detailed "here":#realtime-typing-heartbeat.
-*** @(CHA-T4a5)@ @[Testable]@ Upon successful publish, a timeout shall be set according to the @CHA-T10@ timeout interval. Until this timeout expires, the client shall not publish any further `typing.started` "heartbeats":#realtime-typing-heartbeat.
+*** @(CHA-T4a4)@ @[Testable]@ Upon successful publish, if a value for the @CHA-T3@ timeout interval is defined, a timeout shall be created.
+*** @(CHA-T4a5)@ @[Testable]@ Upon successful publish, a timeout shall be set according to the @CHA-T10@ timeout interval.
 ** @(CHA-T4b)@ This specification point has been removed. It was superseded by @CHA-T4c@.
 ** @(CHA-T4c)@ If typing is already in progress (i.e. a @CHA-T10@ timeout has been defined):
 *** @(CHA-T4c1)@ @[Testable]@ The client must not send a @typing.started@ event.
@@ -448,19 +448,21 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 ** @(CHA-T5a)@ @[Testable]@ If typing is not in progress (i.e. no @CHA-T10@ timeout has been defined), this operation is no-op.
 ** @(CHA-T5b)@ This specification point has been removed.
 ** @(CHA-T5c)@ @[Testable]@ If the channel state is not @ATTACHED@ or @ATTACHING@, the operation shall throw an @ErrorInfo@ with code @40000@.
-** @(CHA-T5b)@ @(deprecated)@ @[Testable]@ If typing is in progress, the @CHA-T3@ and @CHA-T10@ timeouts shall be cancelled, and the client shall publish a heartbeat message with the name field set to `typing.stopped`.
+** @(CHA-T5d)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-heartbeat.
+** @(CHA-T5e)@ @[Testable]@ On successfully publishing the message in @(CHA-T5d)@, the @CHA-T3@ and @CHA-T10@ timers shall be unset.
 * @(CHA-T6)@ Users may subscribe to typing events - updates to a set of clientIDs that are typing. This operation, like all subscription operations, has no side-effects in relation to room lifecycle.
-** @(CHA-T6a)@ @[Testable]@ Users may provide a listener to subscribe to "typing event V1":#chat-structs-typing-event in a room. Note, "typing event V1":#chat-structs-typing-event is a deprecated, please use "typing event V2":#chat-structs-typing-event-V2.
+** @(CHA-T6a)@ @[Testable]@ Users may provide a listener to subscribe to "typing event V2":#chat-structs-typing-event-V2 in a chat room.
 ** @(CHA-T6b)@ @[Testable]@ A subscription to typing may be removed, after which it shall receive no further events.
-** @(CHA-T6c)@ @(deprecated)@ @[Testable]@ When a presence event is received from the realtime client, the Chat client will perform a @presence.get()@ operation to get the current presence set. This guarantees that we get a fully synced presence set. This is then used to emit the typing clients to the subscriber.
-*** @(CHA-T6c1)@ @(deprecated)@ @[Testable]@ If the @presence.get()@ operation fails, then it shall be retried using a backoff with jitter, up to a timeout of 30 seconds.
-*** @(CHA-T6c2)@ @(deprecated)@ @[Testable]@ If multiple presence events are received resulting in concurrent @presence.get()@ calls, then we guarantee that only the "latest" event is emitted. That is to say, if presence event A and B occur in that order, then only the typing event generated by B's call to @presence.get()@ will be emitted to typing subscribers.
-** @(CHA-T6d) @[Testable]@ When a typing heartbeat is received from the realtime client, the Chat client shall emit the updated set of typing clients to the subscriber, along with the clientId of the client that started/stopped typing.
-** @(CHA-T6d1) @[Testable]@ If the typing heartbeat is malformed (unknown fields should be ignored), then it shall not be emitted to the subscriber.
-** @(CHA-T6d2) @[Testable]@ When a typing heartbeat is received from the realtime client;
-*** @(CHA-T6d2a) @[Testable]@ If the heartbeat represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a @(CHA-T10)@ timeout for the typing client.
-*** @(CHA-T6d2b) @[Testable]@ Each additional typing heartbeat from the same client shall reset the @(CHA-T10)@ timeout for the typing client. If the timeout expires, the client shall wait for a further @(CHA-T11)@ time before removing the client from the typing set and emitting the updated set to any subscribers.
-*** @(CHA-T6d2c) @[Testable]@ If the heartbeat represents a client that has stopped typing, then the chat client shall remove the typer from the typing set and emit the updated set to any subscribers. It shall also cancel the @(CHA-T10)@ timeout for the typing client.
+** @(CHA-T6c)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
+*** @(CHA-T6c1)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
+*** @(CHA-T6c2)@ This specification point has been removed, it has been superseded by @CHA-T6d@.
+* @(CHA-T13)@ When a typing heartbeat is received from the realtime client, the Chat client shall emit appropriate events to the user.
+** @(CHA-T13a)@ @[Testable]@ If the typing heartbeat is malformed (unknown fields should be ignored), then it shall not be emitted to the subscriber.
+** @(CHA-T13b)@ @[Testable]@ When a typing heartbeat is received from the realtime client;
+*** @(CHA-T13b1)@ @[Testable]@ If the heartbeat represents a new client typing, then the chat client shall add the typer to the typing set and a emit the updated set to any subscribers. It shall also begin a timeout that is the sum of the @CHA-T10@ heartbeat interval and the @CHA-T11@ grade period.
+*** @(CHA-T13b2)@ @[Testable]@ Each additional typing heartbeat from the same client shall reset the @(CHA-T13b1)@ timeout.
+*** @(CHA-T13b3)@ @[Testable]@ If the @(CHA-T13b1)@ timeout expires, the client shall remove the subject from the typing set and emitting the updated set to any subscribers.
+*** @(CHA-T13b4)@ @[Testable]@ If the heartbeat represents a client that has stopped typing, then the chat client shall remove the typer from the typing set and emit the updated set to any subscribers. It shall also cancel the @(CHA-T13b1)@ timeout for the typing client.
 * @(CHA-T7)@ @[Testable]@ Users may subscribe to discontinuity events to know when there's been a break in typing indicators. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For typing, there shouldn't need to be user action as the underlying core SDK will heal the presence set.
 
 h2(#occupancy). Occupancy


### PR DESCRIPTION
This Pull Request updates the specifications and behavior related to Typing Indicators in Chat.
It removes the old presence based typing system and introduces a new heartbeat-based system, which uses ephemeral messages over a typical WS publish. 

### Main Changes
  - Removed the spec points for the old presence based typing system.
  - Added spec points for the new heartbeat based system.
  - Added new configuration options for heartbeat interval properties.
  - Added new format for typing events that include both `change` and `currentlyTyping` fields.
  - Added  spec around use of ephemeral messages to ensure non-persistence in history.
