### PR TITLE
Add `ACTIVATE` ProtocolMessage Action

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -1410,7 +1410,7 @@ h4. PresenceMessage
 h4. ProtocolMessage
 
 * @(TR1)@ A @ProtocolMessage@ represents the type used to send and receive messages over the Realtime protocol.  A ProtocolMessage always relates either to the connection or to a single channel only, but can contain multiple individual Messages or PresenceMessages.
-* @(TR2)@ @ProtocolMessage@ @Action@ enum has the following values in order from zero: @HEARTBEAT@, @ACK@, @NACK@, @CONNECT@, @CONNECTED@, @DISCONNECT@, @DISCONNECTED@, @CLOSE@, @CLOSED@, @ERROR@, @ATTACH@, @ATTACHED@, @DETACH@, @DETACHED@, @PRESENCE@, @MESSAGE@, @SYNC@, @AUTH@
+* @(TR2)@ @ProtocolMessage@ @Action@ enum has the following values in order from zero: @HEARTBEAT@, @ACK@, @NACK@, @CONNECT@, @CONNECTED@, @DISCONNECT@, @DISCONNECTED@, @CLOSE@, @CLOSED@, @ERROR@, @ATTACH@, @ATTACHED@, @DETACH@, @DETACHED@, @PRESENCE@, @MESSAGE@, @SYNC@, @AUTH@, @ACTIVATE@
 * @(TR3)@ @ProtocolMessage@ @Flag@ enum has the following values, where a flag with value @n@ is defined to be set if the bitwise AND of the @flags@ field with @2ⁿ@ is nonzero
 ** @(TR3a)@ 0: @HAS_PRESENCE@
 ** @(TR3b)@ 1: @HAS_BACKLOG@
@@ -2309,6 +2309,7 @@ enum ProtocolMessageAction: // internal
   MESSAGE // TR2
   SYNC // TR2
   AUTH // TR2
+  ACTIVATE // TR2
 
 class AuthDetails: // AD*
   accessToken: String // AD2, RTC8a

--- a/textile/protocol.textile
+++ b/textile/protocol.textile
@@ -80,6 +80,8 @@ The serial number of the message must be included in the @msgSerial@ field (in t
 
 - AUTH (17) := Sent by the client with a new token to reauthenticate the connection, with the connection either being closed due to incompatible token details being provided, or a @CONNECTED@ message being sent back to the client confirming the authentication succeeded. The server can request that the client authenticates by sending an @AUTH@ protocol message to the client, and the client must respond with a new token in an @AUTH@ protocol message.
 
+- ACTIVATE (18) := Reserved for a deprecated use.
+
 h2(#protocol-message-fields). Protocol Message fields
 
 ProtocolMessages are populated with one or more of the following fields.


### PR DESCRIPTION
[TR2](https://sdk.ably.com/builds/ably/specification/main/features/#TR2) reads as follows:

> ProtocolMessage Action enum has the following values **in order from zero**:

and then lists the enums values.
My intention is to preserve the wording of the TR2 and just add the new actions for LiveObjects: `STATE` and `STATE_SYNC` (https://github.com/ably/specification/pull/279).
And in order to do that, we need to first add the `ACTIVATE` action that is currently missing. Realtime enum: https://github.com/ably/realtime/blob/2fcbe71939df11794e31b29536accf076acdabec/protocol/common.proto#L139, and also added to ably-js even though not part of the spec: https://github.com/ably/ably-js/blob/a7d8181d62fcb2375cdaef3e86eb61c2fa349070/src/common/lib/types/protocolmessagecommon.ts#L23

@SimonWoolf @mschristensen Could you please briefly describe the `ACTIVATE` action so I can write a description for it for the [protocol page](https://github.com/ably/specification/pull/280/files#diff-970e185c37a49bd8aae9281d94475b7ba89a4699bbd07045e51642d39d264fcfR83)?