### PR TITLE
fix: updated `RTN11` spec point

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -525,9 +525,9 @@ h3(#realtime-connection). Connection
 * @(RTN10)@ This clause has been deleted. It was valid up to and including specification version @1.2@.
 * @(RTN11)@ @Connection#connect@ function:
 ** @(RTN11a)@ Explicitly connects to the Ably service if not already connected
-** @(RTN11b)@ If the state is @CLOSING@, the client should make a new connection with a new transport instance and remove all references to the old one. In particular, it should make sure that, when the @CLOSED@ @ProtocolMessage@ arrives for the old connection, it doesn't affect the new one.
+** @(RTN11b)@ If the state is @CLOSING@, the client should make a new connection with a new transport instance and remove all references to the old one. In particular, it should make sure that, when the @CLOSED@ @ProtocolMessage@ arrives for the old connection, it doesn't affect the new one. Additionally, the client should ensure that all channels first transition to @DETACHED@, following "@RTL3b@":#RTL3b, and then reinitialize channels per "@RTN11d@":#RTN11d.
 ** @(RTN11c)@ If the state is @DISCONNECTED@ or @SUSPENDED@, skips the ongoing wait in the retry process described in "RTN14d":#RTN14d and "RTN14e":#RTN14e, so that the next reconnection attempt happens immediately.
-** @(RTN11d)@ If the state is @CLOSED@ or @FAILED@, transitions all the channels to @INITIALIZED@ and unsets their @RealtimeChannel.errorReason@, unsets the @Connection.errorReason@, clears all connection state (including in particular @Connection.recoveryKey@), and resets the @msgSerial@ to @0@
+** @(RTN11d)@ If the state is @CLOSED@ or @FAILED@, transitions all the channels to @INITIALIZED@ and unsets their @RealtimeChannel.errorReason@, clear all internal connection data (including in particular @Connection.errorReason@) and resets the @msgSerial@ to @0@
 * @(RTN12)@ @Connection#close@ function:
 ** @(RTN12f)@ If the connection state is @CONNECTING@, moves immediately to @CLOSING@. If the connection attempt succeeds, ie. a @CONNECTED@ @ProtocolMessage@ arrives from Ably, then do as specified in "RTN12a":#RTN12a. If it doesn't succeed, move to @CLOSED@.
 ** @(RTN12a)@ If the connection state is @CONNECTED@, sends a @CLOSE@ @ProtocolMessage@ to the server, transitions the state to @CLOSING@ and waits for a @CLOSED@ @ProtocolMessage@ to be received


### PR DESCRIPTION
Link [(RTN11)](https://sdk.ably.com/builds/ably/specification/main/features/#RTN11)

- Removed the mention of `recoveryKey` as it has been removed

- Added `CLOSING` to the list of states that should trigger resetting all channels, as there should be no difference for the client whether they wait for the close event to occur or not. The sequence `client.close(); client.connect();` should be deterministic.