### PR TITLE
Restore path in `#time` spec point

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -121,7 +121,7 @@ h3(#restclient). RestClient
 *** @(RSC6b2)@ @direction@ backwards or forwards; if omitted the direction defaults to the REST API default (backwards)
 *** @(RSC6b3)@ @limit@ supports up to 1,000 items; if omitted the limit defaults to the REST API default (100)
 *** @(RSC6b4)@ @unit@ is the period for which the stats will be aggregated by, values supported are @minute@, @hour@, @day@ or @month@; if omitted the unit defaults to the REST API default (@minute@)
-* @(RSC16)@ @RestClient#time@ function sends a get request to the REST endpoint as specified in "@RSC25@":#RSC25 and returns the server time in milliseconds since epoch or as a Date/Time object where suitable
+* @(RSC16)@ @RestClient#time@ function sends a get request to the @/time@ path of the REST endpoint as specified in "@RSC25@":#RSC25 and returns the server time in milliseconds since epoch or as a Date/Time object where suitable
 * @(RSC21)@ @RestClient#push@ attribute provides access to the @Push@ object that was instantiated with the @ClientOptions@ provided in the @RestClient@ constructor
 * @(RSC7)@ Sends REST requests over HTTP and HTTPS to the REST endpoint as specified in "@RSC25@":#RSC25.
 ** @(RSC7a)@ This clause has been replaced by "@RSC7e@":#RSC7e. It was valid up to and including specification version @2.1@.


### PR DESCRIPTION
I guess this was unintentionally removed in 27a1696.