### PR TITLE
Replace term "buffer" with "binary"

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -1367,7 +1367,7 @@ h4. Message
 ** @(TM2c)@ @connectionId@ string. If a message received from Ably does not contain a @connectionId@, it should be set to the @connectionId@ of the encapsulating @ProtocolMessage@
 ** @(TM2h)@ @connectionKey@ string (note this is only ever populated by a publishing client when "publishing on behalf of another client":/rest/messages#publish-on-behalf, the @connectionKey@ will never be populated for messages received. A simple test for this attribute over REST is to populate this with an invalid @connectionKey@ when publishing and expecting a suitable error)
 ** @(TM2g)@ @name@ string
-** @(TM2d)@ @data@ string, buffer or JSON-encodable object or array
+** @(TM2d)@ @data@ string, binary or JSON-encodable object or array
 ** @(TM2e)@ @encoding@ string
 ** @(TM2i)@ @extras@ JSON-encodable object, used to contain any arbitrary key value pairs which may also contain other primitive JSON types, JSON-encodable objects or JSON-encodable arrays. The @extras@ field is provided to contain message metadata and/or ancillary payloads in support of specific functionality, e.g. push. Each of these supported extensions is documented separately; for 1.1 the only supported extension is @push@, via the @extras.push@ member; 1.2 adds the @delta@ extension whose keys and values are described by the attributes of the type @DeltaExtras@, and the @headers@ extension, which contains arbitrary @string->string@ key-value pairs, settable at publish time, and @ref@ whose keys and values are described by the attributes of the type @ReferenceExtras@. Unless otherwise specified, the client library should not attempt to do any filtering or validation of the @extras@ field itself, but should treat it opaquely, encoding it and passing it to realtime unaltered.
 ** @(TM2f)@ @timestamp@ time in milliseconds since epoch. If a message received from Ably over a realtime transport does not contain a @timestamp@, the SDK must set it to the @timestamp@ of the encapsulating @ProtocolMessage@
@@ -1400,7 +1400,7 @@ h4. PresenceMessage
 ** @(TP3b)@ @action@ enum
 ** @(TP3c)@ @clientId@ string
 ** @(TP3d)@ @connectionId@ string. If a presence message received from Ably does not contain a @connectionId@, it should be set to the @connectionId@ of the encapsulating @ProtocolMessage@
-** @(TP3e)@ @data@ string, buffer or JSON-encodable object or array
+** @(TP3e)@ @data@ string, binary or JSON-encodable object or array
 ** @(TP3f)@ @encoding@ string
 ** @(TP3i)@ @extras@ JSON-encodable object, used to contain any arbitrary key value pairs which may also contain other primitive JSON types, JSON-encodable objects or JSON-encodable arrays. The @extras@ field is provided to contain message metadata and/or ancillary payloads in support of specific functionality. For 1.1 no specific functionality is specified for @extras@ in presence messages; 1.2 adds the @headers@ extension, which contains arbitrary @string->string@ key-value pairs, settable at publish time. Unless otherwise specified, the client library should not attempt to do any filtering or validation of the @extras@ field itself, but should treat it opaquely, encoding it and passing it to realtime unaltered.
 ** @(TP3g)@ @timestamp@ time in milliseconds since epoch. If a presence message received from Ably does not contain a @timestamp@, it should be set to the @timestamp@ of the encapsulating @ProtocolMessage@


### PR DESCRIPTION
"binary" is used more frequently in the spec and is a bit more generic than "buffer", so just use "binary".
For more context see the discussion in the PR [1].

[1] https://github.com/ably/specification/pull/279#discussion_r1998799036