### PR TITLE
Specify the behaviour of `#connect` when `CONNECTING`

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -526,7 +526,9 @@ h3(#realtime-connection). Connection
 ** @(RTN9c)@ Is @Null@ when the SDK is in the @CLOSED@, @CLOSING@, @FAILED@, or @SUSPENDED@ states
 * @(RTN10)@ This clause has been deleted. It was valid up to and including specification version @1.2@.
 * @(RTN11)@ @Connection#connect@ function:
-** @(RTN11a)@ Explicitly connects to the Ably service if not already connected
+** @(RTN11a)@ This clause has been replaced by @"RTN11e"@:#RTN11e and @"RTN11f@":#RTN11f. It was valid up to and including specification version @TBD@.
+** @(RTN11e)@ No-op if @CONNECTING@ or @CONNECTED@.
+** @(RTN11f)@ Otherwise, connects to the Ably service. Subsequent spec points describe state-dependent additional behaviours that should occur before this connection attempt.
 ** @(RTN11b)@ If the state is @CLOSING@, the client should make a new connection with a new transport instance and remove all references to the old one. In particular, it should make sure that, when the @CLOSED@ @ProtocolMessage@ arrives for the old connection, it doesn't affect the new one. Additionally, the client should ensure that all channels first transition to @DETACHED@, following "@RTL3b@":#RTL3b, and then reinitialize channels per "@RTN11d@":#RTN11d.
 ** @(RTN11c)@ If the state is @DISCONNECTED@ or @SUSPENDED@, skips the ongoing wait in the retry process described in "RTN14d":#RTN14d and "RTN14e":#RTN14e, so that the next reconnection attempt happens immediately.
 ** @(RTN11d)@ If the state is @CLOSED@ or @FAILED@, transitions all the channels to @INITIALIZED@ and unsets their @RealtimeChannel.errorReason@, clear all internal connection data (including in particular @Connection.errorReason@) and resets the @msgSerial@ to @0@
@@ -956,21 +958,21 @@ h3(#connection-states-operations). @Connection.state@ effects on realtime operat
   <td>@connect@</td>
 
   <!-- When INITIALIZED -->
-  <td>"RTN11a":#RTN11a</td>
+  <td>"RTN11f":#RTN11f</td>
   <!-- When CONNECTING -->
-  <td>No-op</td>
+  <td>No-op ("RTN11e":#RTN11e)</td>
   <!-- When CONNECTED -->
-  <td>No-op</td>
+  <td>No-op ("RTN11e":#RTN11e) </td>
   <!-- When DISCONNECTED -->
-  <td>"RTN11a":#RTN11a, "RTN11c":#RTN11c</td>
+  <td>"RTN11f":#RTN11f, "RTN11c":#RTN11c</td>
   <!-- When SUSPENDED -->
-  <td>"RTN11a":#RTN11a, "RTN11c":#RTN11c</td>
+  <td>"RTN11f":#RTN11f, "RTN11c":#RTN11c</td>
   <!-- When CLOSING -->
-  <td>"RTN11a":#RTN11a, "RTN11b":#RTN11b</td>
+  <td>"RTN11f":#RTN11f, "RTN11b":#RTN11b</td>
   <!-- When CLOSED -->
-  <td>"RTN11a":#RTN11a, "RTN11d":#RTN11d</td>
+  <td>"RTN11f":#RTN11f, "RTN11d":#RTN11d</td>
   <!-- When FAILED -->
-  <td>"RTN11a":#RTN11a, "RTN11d":#RTN11d</td>
+  <td>"RTN11f":#RTN11f, "RTN11d":#RTN11d</td>
 
 </tr>
 

--- a/textile/features.textile
+++ b/textile/features.textile
@@ -962,15 +962,15 @@ h3(#connection-states-operations). @Connection.state@ effects on realtime operat
   <!-- When CONNECTED -->
   <td>No-op</td>
   <!-- When DISCONNECTED -->
-  <td>"RTN11c":#RTN11c</td>
+  <td>"RTN11a":#RTN11a, "RTN11c":#RTN11c</td>
   <!-- When SUSPENDED -->
-  <td>"RTN11c":#RTN11c</td>
+  <td>"RTN11a":#RTN11a, "RTN11c":#RTN11c</td>
   <!-- When CLOSING -->
-  <td>"RTN11b":#RTN11b</td>
+  <td>"RTN11a":#RTN11a, "RTN11b":#RTN11b</td>
   <!-- When CLOSED -->
   <td>"RTN11a":#RTN11a</td>
   <!-- When FAILED -->
-  <td>"RTN11d":#RTN11d</td>
+  <td>"RTN11a":#RTN11a, "RTN11d":#RTN11d</td>
 
 </tr>
 

--- a/textile/features.textile
+++ b/textile/features.textile
@@ -968,7 +968,7 @@ h3(#connection-states-operations). @Connection.state@ effects on realtime operat
   <!-- When CLOSING -->
   <td>"RTN11a":#RTN11a, "RTN11b":#RTN11b</td>
   <!-- When CLOSED -->
-  <td>"RTN11a":#RTN11a</td>
+  <td>"RTN11a":#RTN11a, "RTN11d":#RTN11d</td>
   <!-- When FAILED -->
   <td>"RTN11a":#RTN11a, "RTN11d":#RTN11d</td>
 


### PR DESCRIPTION
The connection states table mentioned this but it wasn't actually specified. From a brief check of a few implementations, this seems to match implementations.

Made a couple of fixes to connection states table whilst I was at it; see commit messages for details.