### PR TITLE
Add tombstones for some deleted spec points

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -152,6 +152,8 @@ h3(#restclient). RestClient
 * @(RSC10)@ If a REST request responds with a token error (401 HTTP status code and an Ably error value @40140 <= code < 40150@), then the Auth class is responsible for reissuing a token and the request should be reattempted, see "RSA4a":#RSA4a and "RSA4b":#RSA4b
 * @(RSC25)@ Requests are sent to the @primary domain@ as determined by "@REC1@":#REC1". New HTTP requests (except where @RSC15f@ applies and a cached fallback host is in effect) are first attempted against the @primary domain@.
 * @(RSC11)@ This clause has been replaced by "@RSC25@":#RSC25. It was valid up to and including specification version @TBD@.
+** @(RSC11a)@ This clause has been replaced by "@RSC25@":#RSC25. It was valid up to and including specification version @TBD@.
+** @(RSC11b)@ This clause has been replaced by "@RSC25@":#RSC25. It was valid up to and including specification version @TBD@.
 * @(RSC12)@ This clause has been replaced by "@RSC25@":#RSC25. It was valid up to and including specification version @TBD@.
 * @(RSC13)@ The client library must use the connection and request timeouts specified in the @ClientOptions@, falling back to the defaults described in @ClientOptions@ below
 * @(RSC15)@ Host Fallback
@@ -161,6 +163,10 @@ h3(#restclient). RestClient
 ** @(RSC15e)@ This clause has been replaced by "@RSC25@":#RSC25. It was valid up to and including specification version @TBD@.
 ** @(RSC15a)@ In the case of an error necessitating use of an alternative host (see "RSC15d":#RSC15d), try @fallback domains@ in random order, continuing to try further domains if "qualifying errors":#RSC15d occur, failing when all have been tried or the configured @httpMaxRetryCount@ has been reached (see "TO3l@":#TO3l5). This ensures that a client library is able to work around routing or other problems for the user's closest datacenter. For example, if a @POST@ request to @main.realtime.ably.net@ fails because the default endpoint is unreachable or unserviceable, then the @POST@ request should be retried again against the fallback hosts in attempt to find an alternate healthy datacenter to service the request
 ** @(RSC15g)@ This clause has been replaced by "@RSC15n@":#RSC15n. It was valid up to and including specification version @TBD@.
+*** @(RSC15g1)@ This clause has been replaced by "@RSC15n@":#RSC15n. It was valid up to and including specification version @TBD@.
+*** @(RSC15g2)@ This clause has been replaced by "@RSC15n@":#RSC15n. It was valid up to and including specification version @TBD@.
+*** @(RSC15g3)@ This clause has been replaced by "@RSC15n@":#RSC15n. It was valid up to and including specification version @TBD@.
+*** @(RSC15g4)@ This clause has been replaced by "@RSC15n@":#RSC15n. It was valid up to and including specification version @TBD@.
 ** @(RSC15h)@ This clause has been replaced by "@REC2@":#REC2. It was valid up to and including specification version @TBD@.
 ** @(RSC15i)@ This clause has been replaced by "@REC2@":#REC2. It was valid up to and including specification version @TBD@.
 ** @(RSC15j)@ Requests to fallback hosts must use a matching Host header as this is necessary when fallbacks are proxied through a CDN. For example, if a request to @main.realtime.ably.net@ fails and will be retried to @c.ably-realtime.com@, the Host header must be set to @c.ably-realtime.com@ in the retried request
@@ -604,6 +610,9 @@ h3(#realtime-connection). Connection
 ** @(RTN17g)@ The fallback behavior described by this section, "RTN17":#RTN17, only applies when the set of @fallback domains@, as determined by "@REC2@":#REC2 is not empty. When the set of @fallback domains@ is empty, failing HTTP requests that would have "qualified for a retry against a fallback host (see RSC15d)":#RSC15d will instead result in an error immediately.
 ** @(RTN17h)@ When the use of fallbacks applies, the set of @fallback domains@ is determined by "@REC2@":#REC2.
 ** @(RTN17b)@ This clause has been replaced by "@RSC17h@":#RSC17h. It was valid up to and including specification version @TBD@.
+*** @(RTN17b1)@ This clause has been replaced by "@RSC17h@":#RSC17h. It was valid up to and including specification version @TBD@.
+*** @(RTN17b2)@ This clause has been replaced by "@RSC17h@":#RSC17h. It was valid up to and including specification version @TBD@.
+*** @(RTN17b3)@ This clause has been replaced by "@RSC17h@":#RSC17h. It was valid up to and including specification version @TBD@.
 ** @(RTN17i)@ By default, every connection attempt is first attempted to the @primary domain@ as specified in "@REC1@"#REC1. The client library must always prefer the primary domain, even if a previous connection attempt to that endpoint has failed. (That is, @RSC15f@ does not apply)
 ** @(RTN17a)@ This clause has been replaced by "@RSC17i@":#RSC17i. It was valid up to and including specification version @TBD@.
 ** @(RTN17j)@ In the case of an error necessitating use of an alternative host (see "RTN17f":#RTN17f), the @Connection@ manager should first check if an internet connection is available by issuing a @GET@ request to the @connectivityCheckUrl@ as determined via "@REC3@"#REC3. If the request succeeds and the text "yes" is included in the body, then the client library can assume it has a viable internet connection and should then immediately retry the connection against @fallback domains@ in random order to find an alternative healthy datacenter.


### PR DESCRIPTION
These subpoints were deleted in 1ef8d1a without adding a tombstone. This is causing the ably-js spec coverage CI job to fail.

Per our contributing guidelines, we should have tombstones for these spec points, so add them.