### PR TITLE
Message: remove refSerial and refType

### DIFF
--- a/textile/api-docstrings.md
+++ b/textile/api-docstrings.md
@@ -783,8 +783,6 @@ Contains an individual message that is sent to, or received from, Ably.
 | timestamp: Time ||| TM2f | Timestamp of when the message was received by Ably, as milliseconds since the Unix epoch. (This is the timestamp of the current version of the message) |
 | serial: String? ||| TM2k | This message's unique serial (an identifier that — unlike the id — will remain the same in all future updates of this message, and can be used to update or delete that message). Lexicographically-comparable with other serials and with the `version` field. |
 | version: String? ||| TM2p | The version of the message, lexicographically-comparable with other versions (that share the same serial) Will differ from the serial only if the message has been updated or deleted. |
-| refSerial: String? ||| TM2l | If this message references another, the serial of that referenced message. |
-| refType: String? ||| TM2m | If this message references another, the type of reference that is. |
 | createdAt: Time? ||| TM2o | The timestamp of the very first version of a given message (will differ from `timestamp` only if the message has been updated or deleted). |
 | operation: Operation? ||| TM2n | In the case of an updated or deleted message, this will contain metadata about the update or delete operation. |
 | connectionKey: String? ||| TM2h | Allows a REST client to publish a message on behalf of a Realtime client. If you set this to the [private connection key]{@link Connection.key} of a Realtime connection when publishing a message using a [`RestClient`]{@link RestClient}, the message will be published on behalf of that Realtime client. This property is only populated by a client performing a publish, and will never be populated on an inbound message. |

--- a/textile/features.textile
+++ b/textile/features.textile
@@ -1446,8 +1446,6 @@ h4. Message
 ** @(TM2p)@ @version@ string - an opaque string that uniquely identifies the message, and is different for different versions. (May not be populated).
 ** @(TM2k)@ @serial@ string - an opaque string that uniquely identifies the message. If a message received from Ably (whether over realtime or REST, eg history) with an @action@ of @MESSAGE_CREATE@ does not contain a @serial@ but does contain a @version@, the SDK must set it equal to the @TM2p@ @version@. (May not be populated).
 ** @(TM2o)@ @createdAt@ time in milliseconds since epoch. If a message received from Ably (whether over realtime or REST, eg history) with an @action@ of @MESSAGE_CREATE@ does not contain a @createdAt@, the SDK must set it equal to the @TM2f@ @timestamp@.
-** @(TM2l)@ @refSerial@ string - an opaque string that uniquely identifies some referenced message.
-** @(TM2m)@ @refType@ string - an opaque string that identifies the type of this reference.
 ** @(TM2n)@ @operation@ - object that may contain the following `optional` attributes;
 *** @(TM2n1)@ @clientId@ string
 *** @(TM2n2)@ @description@ string
@@ -2563,8 +2561,6 @@ class Message: // TM*
   action: MessageAction // TM2j
   serial: string? // TM2k
   version: string? // TM2p
-  refSerial: string? // TM2l
-  refType: string? // TM2m
   operation: Object? // TM2n
   createdAt: Time? // TM2o
   summary: Dict<string, JsonObject>? // TM2q


### PR DESCRIPTION
I think this was added by chat team back when they were looking at doing threading based on message references, before the priorities changed. internal concerns have been raised about the naming of the fields so I'm just removing them given that there's no serverside use of these yet.