### PR TITLE
chore: update `msgSerial` spec point

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -1690,7 +1690,7 @@ h4. ProtocolMessage
 ** @(TR4g)@ @count@ integer
 ** @(TR4h)@ @error@ @ErrorInfo@ object
 ** @(TR4i)@ @flags@ integer. Contains one or more of the bit flags specified in @TR3@
-** @(TR4j)@ @msgSerial@ long
+** @(TR4j)@ @msgSerial@ long. Should be reset to @0@ every clean connection attempt (not a resume attempt). Including reconnect after @SUSPENDED@
 ** @(TR4k)@ @messages@ Array of @Message@ objects
 ** @(TR4l)@ @presence@ Array of @PresenceMessage@ objects
 ** @(TR4m)@ @timestamp@ time in milliseconds since epoch


### PR DESCRIPTION
Clarify that `msgSerial` should reset to `0` on clean connection attempts, including reconnects after `SUSPENDED`.

There is nothing in the spec about going back from `SUSPENDED`, and we have different implementation at least in js and java. js resets `msgSerial` after `suspended`, java doesn't. `msgSerial` reset is mentioned in resume attempts and manual `connect()` after terminal states.