### PR TITLE
Fix nullability of `ObjectsMapEntry.data`

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -2625,7 +2625,7 @@ class ObjectsCounter // OCN*, internal
 class ObjectsMapEntry // OME*, internal
   tombstone: Boolean? // OME2a
   timeserial: String? // OME2b
-  data: ObjectData // OME2c
+  data: ObjectData? // OME2c
 
 class ObjectData // OD*, internal
   objectId: String? // OD2a


### PR DESCRIPTION
I have observed it being absent for a tombstoned map entry received in an `OBJECT_SYNC`. Also RTLM8a2a of #333 at dd25dca tells us to set it to null.