### PR TITLE
spec: clarify behaviour in TM8a

### DIFF
--- a/textile/features.textile
+++ b/textile/features.textile
@@ -1487,7 +1487,7 @@ h4. Message
 *** @(TM7e1)@ @SummaryTotal@ is an object containing:
 **** @(TM7e1a)@ @total@ integer
 * @(TM8)@ The attributes available in a @MessageAnnotations@ object are:
-** @(TM8a)@ @summary@ @Dict<string, JsonObject>@ - an object whose keys are annotation types, and the values are aggregated summaries for that annotation type. A missing @summary@ field on the wire indicates an empty summary, equivalent to an object with no keys.
+** @(TM8a)@ @summary@ @Dict<string, JsonObject>@ - an object whose keys are annotation types, and the values are aggregated summaries for that annotation type. A missing @summary@ field on the wire indicates an empty summary, equivalent to an object with no keys. The SDK must initialize this object if not present.
 *** @(TM8a1)@ A given annotation type has a fixed summary structure, and the currently-used structured are documented for the user's use in api-docstrings. But the sdk MUST be able to cope with structures and aggregation types that have it does not yet know about or have explicit support for, hence the loose (JsonObject) type.
 
 h4. DeltaExtras


### PR DESCRIPTION
It's implied but perhaps not explicitly enough - the SDK should set the empty object for summary if it's not present.