### PR TITLE
chat: error code review

### DIFF
--- a/textile/chat-features.textile
+++ b/textile/chat-features.textile
@@ -37,7 +37,7 @@ h2(#general). General Principles
 * @(CHA-GP3)@ Wherever possible, Chat features should be exposed in the public API as properties of their parent. For example, @messages@ would be considered a property of a @room@ object. This allows for greater composability and extensibility in the future.
 * @(CHA-GP4)@ Avoid overloading methods and optional parameters. Prefer object-type parameters wherever practical and idiomatic.
 * @(CHA-GP5)@ When raising an @ErrorInfo@, avoid relying on the generic @40000@ and @50000@ codes.
-** @(CHA-GP5a)@ Prefer codes already defined in @ably-common@, for example - use @40003@ for an invalid argument passed to a function.
+** @(CHA-GP5a)@ Prefer codes already defined in @ably-common@, for example - use @InvalidArgument@ for an invalid argument passed to a function.
 ** @(CHA-GP5b)@ If the error is chat-specific, define a new code in the @102000 - 103000@ range reserved for chat.
 * @(CHA-GP6)@ Error messages must follow the standard format @unable to <op>; <reason>@.
 ** @(CHA-GP6a)@ Error messages must be written assuming that the audience is the customer developer, not an Ably engineer.
@@ -213,7 +213,7 @@ h4(#rooms-lifecycle-operations). Room Lifecycle Operations
 * @(CHA-RL9)@ Many operations in the Chat SDK will still attempt to proceed if the room is in an @ATTACHING@ status. However, their ability to proceed will depend on the subsequent status that the room takes. This specification point is defined here to avoid unnecessary repetition. It is primarily testable via the points that refer to it.
 ** @(CHA-RL9a)@ @[Testable]@ When the room status is @ATTACHING@ at the point of operation commencement, the caller will subscribe a one-time listener to the room status.
 ** @(CHA-RL9b)@ @[Testable]@ If the next room status received by the caller is @ATTACHED@, the operation shall proceed as normal.
-** @(CHA-RL9c)@ @[Testable]@ If the next room status received is any other value, the operation must throw an error. The @ErrorInfo@ shall have the @RoomInInvalidState@ error code from the "chat-specific error codes":#error-codes, with a status code of @500@. The @cause@ field must contain any error associated with the room status change, if present.
+** @(CHA-RL9c)@ @[Testable]@ If the next room status received is any other value, the operation must throw an error. The @ErrorInfo@ shall have the @RoomInInvalidState@ error code from the "chat-specific error codes":#error-codes. The @cause@ field must contain any error associated with the room status change, if present.
 ** @(CHA-RL9d)@ @[Testable]@ Once execution has resumed, the client MAY check the room status again, to handle spurious changes or race conditions.
 * @(CHA-RL10)@ This specification point has been removed. It was valid up until the single-channel migration.
 * @(CHA-RL5)@ This specification point has been removed. It was valid up until the single-channel migration.
@@ -272,8 +272,8 @@ Each chat room can be configured individually, allowing options to be passed as 
 ** @(CHA-RC1a)@ This specification point has been removed. It was superseded by CHA-RC1f.
 ** @(CHA-RC1f)@ @[Testable]@ Requesting a room from the Chat Client shall return a future, that eventually resolves to an instance of a room with the provided id and (optional) options.
 *** @(CHA-RC1f7)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-*** @(CHA-RC1f8)@ @[Testable]@ If the @Rooms@ instance has been disposed (following a call to @dispose@), attempting to get a room must throw an error with code @40014@.
-*** @(CHA-RC1f1)@ @[Testable]@ If the room name exists in the room map, but the room has been requested with different options, then an @ErrorInfo@ with the @BadRequest@ error code from the "chat-specific error codes":#error-codes and a @statusCode@ of 400 shall be thrown.
+*** @(CHA-RC1f8)@ @[Testable]@ If the @Rooms@ instance has been disposed (following a call to @dispose@), attempting to get a room must throw an error with code @ResourceDiposed@.
+*** @(CHA-RC1f1)@ @[Testable]@ If the room name exists in the room map, but the room has been requested with different options, then an @ErrorInfo@ with the @RoomExistsWithDifferentOptions@ error code from the "chat-specific error codes":#error-codes shall be thrown.
 *** @(CHA-RC1f2)@ @[Testable]@ If the room name exists in the room map, and it is requested with the same options, then the same instance of the room must be reused.
 *** @(CHA-RC1f3)@ @[Testable]@ If no @CHA-RC1g@ release operation is in progress, a new room instance shall be created, added to the room map and returned as the future value.
 *** @(CHA-RC1f4)@ @[Testable]@ If a @CHA-RC1g@ release operation is in progress, the entry shall be added to the room map, but the new room instance must not be created until the release operation has resolved. The future shall then subsequently resolve with the new room value.
@@ -288,12 +288,12 @@ Each chat room can be configured individually, allowing options to be passed as 
 *** @(CHA-RC1g1)@ The release operation returns a future that shall resolve when the operation completes.
 *** @(CHA-RC1g2)@ @[Testable]@ If the room does not exist in the room map, and no release operation is in progress, this operation is no-op.
 *** @(CHA-RC1g3)@ @[Testable]@ If the room does not exist in the room map, and a release operation is already in progress, then the associated future will be returned.
-*** @(CHA-RC1g4)@ @[Testable]@ If a release operation is already in progress, any pending @CHA-RC1f@ future shall be rejected / throw an error. The error must use the @RoomReleasedBeforeOperationCompleted@ error code from the "chat-specific error codes":#error-codes and a @statusCode@ of 400. The room shall be removed from the room map and the operation must return the future associated with the previous operation.
+*** @(CHA-RC1g4)@ @[Testable]@ If a release operation is already in progress, any pending @CHA-RC1f@ future shall be rejected / throw an error. The error must use the @RoomReleasedBeforeOperationCompleted@ error code from the "chat-specific error codes":#error-codes. The room shall be removed from the room map and the operation must return the future associated with the previous operation.
 *** @(CHA-RC1g5)@ @[Testable]@ The room is removed from the room map and a @CHA-RL3@ release operation is initiated for the room object. A future is returned which resolves when the release operation completes.
 *** @(CHA-RC1g6)@ @[Testable]@ Once the @CHA-RL3@ release operation completes, each individual feature must be cleaned up for garbage collection via its individual @dispose@ method.
 * @(CHA-RC5)@ @[Testable]@ All chat feature properties (e.g. @room.messages@) are enabled by default. The specific behaviour of each feature is controlled by its respective room options @CHA-RC2@.
 * @(CHA-RC2)@ Chat rooms are configurable, so as to enable or disable certain functionality. When requesting a room, options as to what functionality should be enabled/disabled, can be provided (@RoomOptions@).
-** @(CHA-RC2a)@ @[Testable]@ If a room is requested with invalid configuration, for example: a negative typing timeout, an @ErrorInfo@ with code @40003@ must be thrown.
+** @(CHA-RC2a)@ @[Testable]@ If a room is requested with invalid configuration, for example: a negative typing timeout, an @ErrorInfo@ with code @InvalidArgument@ must be thrown.
 ** @(CHA-RC2c)@ This specification point has been removed. It was valid up until the single-channel migration.
 ** @(CHA-RC2b)@ This specification point has been removed. It was valid up until the single-channel migration.
 ** @(CHA-RC2d)@ This specification point has been removed. It was valid up until the single-channel migration.
@@ -362,7 +362,7 @@ Broadly speaking, messages are published via REST calls to the Chat HTTP API and
 ** @(CHA-M8e)@ @[Testable]@ A client must be able to update a message without requiring the full @Message@ type. At minimum, it must be able to provide a @serial@ string and an object/other parameters to update and an (optional) operation information.
 *** @(CHA-M8e1) The exact idiom for the method signature is left to the best practice for the language.
 ** @(CHA-M8f)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-** @(CHA-M8g)@ @[Testable]@ If the @serial@ passed to this method is invalid: @undefined, null, empty string@, an error with code 40003 must be thrown.
+** @(CHA-M8g)@ @[Testable]@ If the @serial@ passed to this method is invalid: @undefined, null, empty string@, an error with code @InvalidArgument@ must be thrown.
 * @(CHA-M9)@ A client must be able to delete a message in a room.
 ** @(CHA-M9a)@ @[Testable]@ A client may delete a message via the Chat REST API by calling the @delete@ method.
 ** @(CHA-M9b)@ @[Testable]@ When a message is deleted successfully via the REST API, the caller shall receive a struct representing the "Messagev4":#chat-structs-message-v4 in response, as if it were received via Realtime event.
@@ -371,7 +371,7 @@ Broadly speaking, messages are published via REST calls to the Chat HTTP API and
 ** @(CHA-M9d)@ @[Testable]@ A client must be able to delete a message without requiring the full @Message@ type. At minimum, it must be able to provide a @serial@ string and an (optional) operation information.
 *** @(CHA-M9d1) The exact idiom for the method signature is left to the best practice for the language.
 ** @(CHA-M9e)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-** @(CHA-M9f)@ @[Testable]@ If the @serial@ passed to this method is invalid: @undefined, null, empty string@, an error with code 40003 must be thrown.
+** @(CHA-M9f)@ @[Testable]@ If the @serial@ passed to this method is invalid: @undefined, null, empty string@, an error with code @InvalidArgument@ must be thrown.
 * @(CHA-M4)@ Messages can be received via a subscription in realtime.
 ** @(CHA-M4a)@ @[Testable]@ A subscription can be registered to receive incoming messages. Adding a subscription has no side effects on the status of the room or the underlying realtime channel.
 ** @(CHA-M4b)@ @[Testable]@ A subscription can de-registered from incoming messages. Removing a subscription has no side effects on the status of the room or the underlying realtime channel.
@@ -412,13 +412,13 @@ Broadly speaking, messages are published via REST calls to the Chat HTTP API and
 * @(CHA-M7)@ This specification point has been removed. It was valid up until the single-channel migration.
 * @(CHA-M11)@ A @Message@ must have a method @with@ to apply changes from events (@MessageEvent@ and @MessageReactionSummaryEvent@) to produce updated message instances.
   ** @(CHA-M11a)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-  ** @(CHA-M11h)@ @[Testable]@ When the method receives a @MessageEvent@ of type @created@, it must throw an @ErrorInfo@ with code @40003@ and status code @400@.
+  ** @(CHA-M11h)@ @[Testable]@ When the method receives a @MessageEvent@ of type @created@, it must throw an @ErrorInfo@ with code @InvalidArgument@.
   ** @(CHA-M11b)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-  ** @(CHA-M11i)@ @[Testable]@ For @MessageEvent@ the method must verify that the @message.serial@ in the event matches the message's own serial. If they don't match, an error with code @40003@ and status code @400@ must be thrown.
+  ** @(CHA-M11i)@ @[Testable]@ For @MessageEvent@ the method must verify that the @message.serial@ in the event matches the message's own serial. If they don't match, an error with code @InvalidArgument@ must be thrown.
   ** @(CHA-M11c)@ @[Testable]@ For @MessageEvent@ of type @update@ and @delete@, if the event message is older or the same (see CHA-M10), the original message must be returned unchanged.
   ** @(CHA-M11d)@ @[Testable]@ For @MessageEvent@ of type @update@ and @delete@, if the event message is newer (see CHA-M10), the method must return a new message based on the event and deep-copying the reactions from the original message.
   ** @(CHA-M11e)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-  ** @(CHA-M11j)@ @[Testable]@ For @MessageReactionSummaryEvent@, the method must verify that the @messageSerial@ in the event matches the message's own serial. If they don't match, an error with code @40003@ and status code @400@ must be thrown.
+  ** @(CHA-M11j)@ @[Testable]@ For @MessageReactionSummaryEvent@, the method must verify that the @messageSerial@ in the event matches the message's own serial. If they don't match, an error with code @InvalidArgument@ must be thrown.
   ** @(CHA-M11f)@ @[Testable]@ For @MessageReactionSummaryEvent@, the method must return a new @Message@ instance (deep copy) with the updated reactions, preserving all other properties of the original message.
   ** @(CHA-M11g)@ @[Testable]@ For @MessageReactionSummaryEvent@, the method must deep-copy the reactions from the event before applying them to the returned message instance.
 * @(CHA-M12)@ @[Testable]@ The @Messages@ instance must provide an internal disposal mechanism, that removes all user-provided listeners, and un-registers any internal listeners that have been associated with the Realtime channel.
@@ -445,7 +445,7 @@ Users can add reactions to messages, such as thumbs-up or heart emojis. Summarie
 * @(CHA-MR4)@ @[Testable]@ Users should be able to send a reaction to a message via the `send` method of the `MessagesReactions` object (@room.messages.reactions.send@).
 ** @(CHA-MR4a)@ @[Testable]@ The `send` method accepts a message serial as the first parameter to identify which message to react to.
 *** @(CHA-MR4a1)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-*** @(CHA-MR4a2)@ @[Testable]@ If the @serial@ passed to this method is invalid: @undefined, null, empty string@, an error with code 40003 must be thrown.
+*** @(CHA-MR4a2)@ @[Testable]@ If the @serial@ passed to this method is invalid: @undefined, null, empty string@, an error with code @InvalidArgument@ must be thrown.
 ** @(CHA-MR4b)@ @[Testable]@ The `send` method accepts a `params` object as the second parameter with the following properties:
 *** @(CHA-MR4b1)@ @[Testable]@ A `name` property (required) specifying the reaction identifier (e.g., emoji string).
 *** @(CHA-MR4b2)@ @[Testable]@ A `type` property (optional) specifying the reaction type. If not provided, the default reaction type for the room is used.
@@ -454,7 +454,7 @@ Users can add reactions to messages, such as thumbs-up or heart emojis. Summarie
 * @(CHA-MR11)@ @[Testable]@ Users should be able to delete a reaction from a message via the `delete` method of the `MessagesReactions` object (@room.messages.reactions.delete@).
 ** @(CHA-MR11a)@ @[Testable]@ The `delete` method accepts a message serial as the first parameter to identify which message to delete the reaction from.
 *** @(CHA-MR11a1)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-*** @(CHA-MR11a2)@ @[Testable]@ If the @serial@ passed to this method is invalid: @undefined, null, empty string@, an error with code 40003 must be thrown.
+*** @(CHA-MR11a2)@ @[Testable]@ If the @serial@ passed to this method is invalid: @undefined, null, empty string@, an error with code @InvalidArgument@ must be thrown.
 ** @(CHA-MR11b)@ @[Testable]@ The `delete` method accepts a `params` object as the second parameter with the following properties:
 *** @(CHA-MR11b1)@ @[Testable]@ A `name` property specifying the reaction identifier (e.g., emoji string). It is required for all reaction types except for @Unique@.
 *** @(CHA-MR11b2)@ @[Testable]@ A `type` property (optional) specifying the reaction type. If not provided, the default reaction type for the room is used.
@@ -470,7 +470,7 @@ Users can add reactions to messages, such as thumbs-up or heart emojis. Summarie
 
 * @(CHA-MR7)@ @[Testable]@ Users must be able to subscribe to raw message reactions (as individual annotations) via the @subscribeRaw@ method of the @MessagesReactions@ object (@room.messages.reactions.subscribeRaw@). The events emitted are of type @MessageReactionRawEvent@.
   ** @(CHA-MR7a)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-  ** @(CHA-MR7c)@ @[Testable]@ The attempt to subscribe to raw message reactions must throw an @ErrorInfo@ using the @FeatureNotEnabledInRoom@ error code from the "chat-specific error codes":#error-codes with a status code of @400@ if the room is not configured to support raw message reactions (when room option @RoomOptions.messages.rawMessageReactions@ is not set to @true@; it defaults to @false@).
+  ** @(CHA-MR7c)@ @[Testable]@ The attempt to subscribe to raw message reactions must throw an @ErrorInfo@ using the @FeatureNotEnabledInRoom@ error code from the "chat-specific error codes":#error-codes if the room is not configured to support raw message reactions (when room option @RoomOptions.messages.rawMessageReactions@ is not set to @true@; it defaults to @false@).
   ** @(CHA-MR7b)@ @[Testable]@ Invalid reaction events received over realtime must still produce an event, but with fields filled in with default values.
     *** @(CHA-MR7b1)@ @[Testable]@ If the reaction type (e.g. unique, distinct) is unknown - the event shall be ignored (we would be guessing the semantics and likely get it wrong).
     *** @(CHA-MR7b2)@ @[Testable]@ If the reaction action type (e.g. add, remove) is unknown - the event shall be ignored (we would be guessing the semantics and likely get it wrong).
@@ -501,7 +501,7 @@ All ephemeral room reactions are handled over the Realtime connection.
 * @(CHA-ER3)@ Ephemeral room reactions are sent to Ably via the Realtime connection via a @send@ method.
 ** @(CHA-ER3a)@ This specification point was removed. It was valid until the single-channel migration.
 ** @(CHA-ER3f)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-** @(CHA-ER3g)@ @[Testable]@ If the connection state is not @CONNECTED@, the operation shall throw an @ErrorInfo@ with code @80003@.
+** @(CHA-ER3g)@ @[Testable]@ If the connection state is not @CONNECTED@, the operation shall throw an @ErrorInfo@ with code @Disconnected@.
 ** @(CHA-ER3d)@ @[Testable]@ Reactions are sent on the channel using an @ephemeral@ message in "this format":#realtime-room-reactions.
 ** @(CHA-ER3b)@ This clause has been deleted.
 ** @(CHA-ER3c)@ This clause has been deleted.
@@ -535,7 +535,7 @@ Presence allows chat room users to indicate to others that they're online, as we
 *** @(CHA-PR3c1) This specification point has been removed.
 *** @(CHA-PR3c2)@ This specification point has been removed.
 ** @(CHA-PR3d)@ @[Testable]@ If the room status is @Attaching@, then the operation shall invoke a @CHA-RL9@ pending room status operation and wait for it to complete. If this operation fails, then the error from @CHA-RL9@ must be raised. If this succeeds (i.e the room becomes @ATTACHED@), the library must invoke the underlying @presence.enter()@ call.
-** @(CHA-PR3h)@ @[Testable]@ If the room status is anything other than @Attached@ or @Attaching@, an @ErrorInfo@ using the @RoomInInvalidState@ error code from the "chat-specific error codes":#error-codes with a status code of @400@ must be thrown. The message shall explain that attach must be called first.
+** @(CHA-PR3h)@ @[Testable]@ If the room status is anything other than @Attached@ or @Attaching@, an @ErrorInfo@ using the @RoomInInvalidState@ error code from the "chat-specific error codes":#error-codes must be thrown. The message shall explain that attach must be called first.
 ** @(CHA-PR3e)@ @[Testable]@ If the room status is @Attached@, then the @enter@ call will invoke the underlying @presence.enter()@ call.
 ** @(CHA-PR3f)@ This specification point has been removed. It was superseded by @CHA-PR3h@.
 ** @(CHA-PR3g)@ This specification point has been removed. It was superseded by @CHA-PR3h@.
@@ -546,7 +546,7 @@ Presence allows chat room users to indicate to others that they're online, as we
 *** @(CHA-PR10c1)@ This specification point has been removed.
 *** @(CHA-PR10c2)@ This specification point has been removed.
 ** @(CHA-PR10d)@ @[Testable]@ If the room status is @Attaching@, then the operation shall invoke a @CHA-RL9@ pending room status operation and wait for it to complete. If this operation fails, then the error from @CHA-RL9@ must be raised. If this succeeds (i.e the room becomes @ATTACHED@), the library must invoke the underlying @presence.update()@ call.
-** @(CHA-PR10h)@ @[Testable]@ If the room status is anything other than @Attached@ or @Attaching@, an @ErrorInfo@ using the @RoomInInvalidState@ error code from the "chat-specific error codes":#error-codes with a status code of @400@ must be thrown. The message shall explain that attach must be called first.
+** @(CHA-PR10h)@ @[Testable]@ If the room status is anything other than @Attached@ or @Attaching@, an @ErrorInfo@ using the @RoomInInvalidState@ error code from the "chat-specific error codes":#error-codes must be thrown. The message shall explain that attach must be called first.
 ** @(CHA-PR10e)@ @[Testable]@ If the room status is @Attached@, then the @update@ call will invoke the underlying @presence.enter()@ call.
 ** @(CHA-PR10f)@ This specification point has been removed. It was superseded by @CHA-PR10h@.
 ** @(CHA-PR10g)@ This specification point has been removed. It was superseded by @CHA-PR10h@.
@@ -559,13 +559,13 @@ Presence allows chat room users to indicate to others that they're online, as we
 *** @(CHA-PR6b1)@ This specification point has been removed.
 *** @(CHA-PR6b2)@ This specification point has been removed.
 ** @(CHA-PR6c)@ @[Testable]@ If the room status is @Attaching@, then the operation shall invoke a @CHA-RL9@ pending room status operation and wait for it to complete. If this operation fails, then the error from @CHA-RL9@ must be raised. If this succeeds (i.e the room becomes @ATTACHED@), the library must invoke the underlying @presence.get()@ call.
-** @(CHA-PR6h)@ @[Testable]@ If the room status is anything other than @Attached@ or @Attaching@, an @ErrorInfo@ using the @RoomInInvalidState@ error code from the "chat-specific error codes":#error-codes with a status code of @400@ must be thrown. The message shall explain that attach must be called first.
+** @(CHA-PR6h)@ @[Testable]@ If the room status is anything other than @Attached@ or @Attaching@, an @ErrorInfo@ using the @RoomInInvalidState@ error code from the "chat-specific error codes":#error-codes must be thrown. The message shall explain that attach must be called first.
 ** @(CHA-PR6d)@ @[Testable]@ If the room status is @Attached@, then the @get@ call will invoke the underlying @presence.get()@ call.
 ** @(CHA-PR6e)@ This specification point has been removed. It was superseded by @CHA-PR6h@.
 ** @(CHA-PR6f)@ This specification point has been removed. It was superseded by @CHA-PR6h@.
 * @(CHA-PR7)@ Users may subscribe to presence events.
 ** @(CHA-PR7d)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-** @(CHA-PR7e)@ @[Testable]@ If presence events have been disabled per @CHA-PR9c@, then the client shall throw an @ErrorInfo@ using the @FeatureNotEnabledInRoom@ error code from the "chat-specific error codes":#error-codes with a status code of @400@.
+** @(CHA-PR7e)@ @[Testable]@ If presence events have been disabled per @CHA-PR9c@, then the client shall throw an @ErrorInfo@ using the @FeatureNotEnabledInRoom@ error code from the "chat-specific error codes":#error-codes.
 ** @(CHA-PR7a)@ @[Testable]@ Users may provide a listener to subscribe to all "presence events":#chat-structs-presence-event-v2 in a room.
 ** @(CHA-PR7b)@ @[Testable]@ This specification point has been removed.
 ** @(CHA-PR7c)@ @[Testable]@ A subscription to presence may be removed, after which it shall receive no further events.
@@ -601,7 +601,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 * @(CHA-T4)@ Users may indicate that they have started typing using the @keystroke@ method.
 ** @(CHA-T4d)@ This specification point has been removed. It was valid until the V1 API Review.
 ** @(CHA-T4e)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-** @(CHA-T4f)@ @[Testable]@ If the connection state is not @CONNECTED@, the operation shall throw an @ErrorInfo@ with code @80003@.
+** @(CHA-T4f)@ @[Testable]@ If the connection state is not @CONNECTED@, the operation shall throw an @ErrorInfo@ with code @Disconnected@.
 ** @(CHA-T4a)@ If typing is not already in progress (i.e. a heartbeat timer has not been set by the successful publish @CHA-T4a4@ of a @typing.started@ event):
 *** @(CHA-T4a1)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
 *** @(CHA-T4a2)@ This specification point has been removed. It was replaced by @CHA-T4a3+@.
@@ -616,7 +616,7 @@ For the purpose of this section, an @ephemeral message@ is understood to mean a 
 ** @(CHA-T5b)@ This specification point has been removed.
 ** @(CHA-T5c)@ This specification point has been removed. It was valid until the V1 API Review.
 ** @(CHA-T5f)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-** @(CHA-T5g)@ @[Testable]@ If the connection state is not @CONNECTED@, the operation shall throw an @ErrorInfo@ with code @80003@.
+** @(CHA-T5g)@ @[Testable]@ If the connection state is not @CONNECTED@, the operation shall throw an @ErrorInfo@ with code @Disconnected@.
 ** @(CHA-T5d)@ @[Testable]@ The client shall publish an ephemeral message to the channel with the name field set to @typing.stopped@, the format of which is detailed "here":#realtime-typing-message. The client must wait for the publish to succeed or fail before returning the result to the caller.
 ** @(CHA-T5d1)@ @[Testable]@ The client must wait for the publish to succeed or fail before returning the result to the caller. If the publish fails, the client must handle this transparently and re-throw the error directly to the caller.
 ** @(CHA-T5e)@ @[Testable]@ On successfully publishing the message in @(CHA-T5d)@, the @CHA-T4a4@ timer shall be unset.
@@ -654,7 +654,7 @@ the overhead of having everyone in presence.
 * @(CHA-O3)@ @[Testable]@ Users can request an instantaneous occupancy check via the REST API. The request is detailed "here":#rest-occupancy-request, with the response format being a simple "occupancy data struct":#chat-structs-occupancy-data
 * @(CHA-O4)@ Users can subscribe to realtime occupancy updates.
 ** @(CHA-O4e)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-** @(CHA-O4h)@ @[Testable]@ If occupancy events have been disabled per @CHA-O6@, then the client shall throw an @ErrorInfo@ using the @FeatureNotEnabledInRoom@ error code from the "chat-specific error codes":#error-codes with a status code of @400@.
+** @(CHA-O4h)@ @[Testable]@ If occupancy events have been disabled per @CHA-O6@, then the client shall throw an @ErrorInfo@ using the @FeatureNotEnabledInRoom@ error code from the "chat-specific error codes":#error-codes.
 ** @(CHA-O4a)@ @[Testable]@ Users may register a listener that receives occupancy events in realtime.
 ** @(CHA-O4b)@ @[Testable]@ A subscription to occupancy events may be removed, after which it shall receive no further events.
 ** @(CHA-O4c)@ This specification point has been removed. It was valid until the V1 API Review.
@@ -670,7 +670,7 @@ the overhead of having everyone in presence.
 ** @(CHA-O7a)@ @[Testable]@ The @current@ method should return the latest occupancy numbers received over the realtime connection in a @[meta]occupancy@ event.
 ** @(CHA-O7b)@ @[Testable]@ If no realtime events have been received yet, @current()@ returns undefined/null.
 ** @(CHA-O7c)@ This specification point has been removed. It was valid up until the pre-v1 error code review.
-** @(CHA-O7d)@ @[Testable]@ If occupancy events are not enabled via @RoomOptions.occupancy.enableEvents@, @current()@ throws an @ErrorInfo@ using the @FeatureNotEnabledInRoom@ error code from the "chat-specific error codes":#error-codes with a status code of @400@.
+** @(CHA-O7d)@ @[Testable]@ If occupancy events are not enabled via @RoomOptions.occupancy.enableEvents@, @current()@ throws an @ErrorInfo@ using the @FeatureNotEnabledInRoom@ error code from the "chat-specific error codes":#error-codes.
 * @(CHA-O8)@ @[Testable]@ The @Occupancy@ instance must provide an internal disposal mechanism, that removes all user-provided listeners, and un-registers any internal listeners that have been associated with the Realtime channel.
 
 h2(#rest-api). Chat HTTP REST API
@@ -1592,9 +1592,11 @@ h3(#chat-structs-occupancy-data). Occupancy Data
   }
 </pre>
 
-h2(#common-error-codes). Commmon Error Codes used by Chat
+h2(#common-error-codes). Common Error Codes used by Chat
 
-This section contains error codes that are common across Ably, but the Chat SDK makes use of.
+This section contains error codes that are common across Ably, but the Chat SDK makes use of. The status code for the error should align with the error code (i.e. 4xxxx and 5xxxx shall have statuses 400 and 500 respectively).
+
+The codes listed here shall be defined in any error enums that exist in client library.
 
 <pre>
     // The request was invalid.
@@ -1634,9 +1636,9 @@ h2(#error-codes). Chat-specific Error Codes
 
 This section contains error codes that are specific to Chat. If a specific error code is not listed for a given circumstance, the most appropriate general error code shall be used according to the guidelines of @CHA-GP5@. For example @400xx@ for client errors or @500xx@ for server errors.
 
-For non-chat-specific codes, the status code for the error should align with the error code. For example, error code @40000@ should have status code @400@.
-
 The chat reserved error code range is @102000 - 102999@.
+
+The codes listed here shall be defined in any error enums that exist in client library.
 
 <pre>
 
@@ -1659,18 +1661,6 @@ The chat reserved error code range is @102000 - 102999@.
     // Feature is not enabled in room options.
     // To be accompanied by status code 400.
     FeatureNotEnabledInRoom = 102108,
-
-    // Listener has not been subscribed yet (used in messages historyBeforeSubscribe).
-    // To be accompanied by status code 400.
-    ListenerNotSubscribed = 102109,
-
-    // Channel serial is not defined when expected.
-    // To be accompanied by status code 500.
-    ChannelSerialNotDefined = 102110,
-
-    // Channel options cannot be modified after the channel has been requested.
-    // To be accompanied by status code 400.
-    ChannelOptionsCannotBeModified = 102111,
 
     // Failed to enforce sequential execution of the operation.
     // To be accompanied by status code 500.


### PR DESCRIPTION
This change relates to https://github.com/ably/ably-chat-js/pull/672 and makes changes to the error codes used in Chat to reduce over-usage of 40000 and 50000.

Also included is guidance on the format of error messages and how to use codes.

[CHA-1207]
[CHA-1212]

[CHA-1207]: https://ably.atlassian.net/browse/CHA-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CHA-1212]: https://ably.atlassian.net/browse/CHA-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ