### PR TITLE
Add some warnings on channels.release()

### DIFF
--- a/specifications/api-docstrings.md
+++ b/specifications/api-docstrings.md
@@ -255,7 +255,7 @@ Creates and destroys [`RestChannel`]{@link RestChannel} and [`RealtimeChannel`]{
 ||| `ChannelType` || A [`RealtimeChannel`]{@link RealtimeChannel} object. |
 | iterate() -> `Iterator<ChannelType>` ||| RSN2, RTS2 | Iterates through the existing channels. |
 ||| `ChannelType` || Each iteration returns a [`RestChannel`]{@link RestChannel} or [`RealtimeChannel`]{@link RealtimeChannel} object. |
-| release(String) ||| RSN4, RTS4 | Releases a [`RestChannel`]{@link RestChannel} or [`RealtimeChannel`]{@link RealtimeChannel} object, deleting it, and enabling it to be garbage collected. It also removes any listeners associated with the channel. To release a channel, the [`ChannelState`]{@link ChannelState} must be `INITIALIZED`, `DETACHED`, or `FAILED`. |
+| release(String) ||| RSN4, RTS4 | Releases all SDK-held references to a [`RestChannel`]{@link RestChannel} or [`RealtimeChannel`]{@link RealtimeChannel} object, enabling it to be garbage collected. Warning: this method has no guardrails; using a channel reference after it has been `release()`d is undefined behaviour. It can be useful for applications that work with a continually changing set of channels on a single client and need to avoid unbounded memory growth; if this does not describe you, don't call it. Realtime channels not already in the `INITIALIZED`, `DETACHED`, or `FAILED` state are detached before release.  |
 || `String` ||| The channel name. |
 
 ## class RestChannel


### PR DESCRIPTION
The current docstring almost makes it sound like we expect people to call release(). 99% of people should not. There's a reason the original ably-js comment on this method was   `/* Included to support certain niche use-cases; most users should ignore this. Please do not use this unless you know what you're doing */`
