### PR TITLE
spec/ait: add server-side channel continuity

### DIFF
--- a/specifications/ai-transport-features.md
+++ b/specifications/ai-transport-features.md
@@ -112,7 +112,12 @@ The server transport manages the server-side turn lifecycle over an Ably channel
 
 ### Transport Close
 
-- `(AIT-ST11)` `close()` must unsubscribe from cancel messages, abort all registered turns, and clean up the turn manager.
+- `(AIT-ST11)` `close()` must unsubscribe from cancel messages, abort all registered turns, and clean up the turn manager. It must also stop listening for channel state changes (AIT-ST12). `close()` must be idempotent.
+
+### Channel Continuity
+
+- `(AIT-ST12)` The server transport must monitor the channel for continuity loss. Continuity is lost when the channel enters FAILED, SUSPENDED, or DETACHED, or re-attaches with `resumed: false`.
+  - `(AIT-ST12a)` On continuity loss, the error must be emitted via the transport-level `onError` callback with code `ChannelContinuityLost` (104006). Active turns must not be automatically aborted, and the per-turn `onError` callback must not be invoked, since continuity loss is not scoped to any turn. The SDK user is responsible for reacting (e.g. iterating active turns or aborting their own external signals) if they wish to terminate in-flight work.
 
 ## Client Transport {#client-transport}
 


### PR DESCRIPTION
Server-side counterpart to AIT-597. Add AIT-ST12/AIT-ST12a requiring the server transport to monitor the channel for continuity loss (FAILED, SUSPENDED, DETACHED, or re-attach with resumed:false) and surface it via the transport-level onError callback with ChannelContinuityLost (104006). Active turns are not auto-aborted and the per-turn onError is not invoked — continuity loss is channel-wide, not turn-scoped, and the server's only inbound channel traffic is cancel messages (missing one is survivable).

Amend AIT-ST11 to require close() to also stop listening for channel state changes (AIT-ST12) and to be idempotent.

Companion SDK PR: https://github.com/ably/ably-ai-transport-js/pull/65

[AIT-695]

[AIT-695]: https://ably.atlassian.net/browse/AIT-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ