### PR TITLE
[AIT-667] spec/ait: align AIT-ST4b with turn-lifecycle error pattern

### DIFF
--- a/specifications/ai-transport-features.md
+++ b/specifications/ai-transport-features.md
@@ -86,7 +86,7 @@ The server transport manages the server-side turn lifecycle over an Ably channel
   - `(AIT-ST3a)` The turn must be registered for cancel routing immediately on creation, so that cancel messages arriving before `start()` still fire the turn's abort signal.
 - `(AIT-ST4)` `start()` must publish a turn-start event (`x-ably-turn-start`) with the turn's `x-ably-turn-id` and `x-ably-turn-client-id` headers. It must be idempotent.
   - `(AIT-ST4a)` If the turn was cancelled before `start()`, `start()` must raise an error.
-  - `(AIT-ST4b)` If the turn-start publish fails, the per-turn `onError` callback must be invoked and the error re-thrown.
+  - `(AIT-ST4b)` If the turn-start publish fails, `start()` must reject with an `Ably.ErrorInfo` carrying code `TurnLifecycleError` and wrapping the underlying error as `cause`. The per-turn `onError` callback must NOT be invoked — the rejected promise is the sole delivery channel.
 - `(AIT-ST5)` `addMessages()` must accept `TreeNode[]` and require that `start()` has been called. For each node, it must create a codec encoder with transport headers built from the node's typed fields (`msgId`, `parentId`, `forkOf`) merged with its `headers`, and publish the message through the encoder.
   - `(AIT-ST5a)` Per-node `parentId` and `forkOf` fields take precedence; turn-level defaults apply when those fields are undefined.
   - `(AIT-ST5b)` `addMessages()` must return an `AddMessagesResult` containing the `msgId` of each published node, in order. This allows the caller to pass the last msg-id as the assistant message's parent.


### PR DESCRIPTION
## Summary

Aligns `AIT-ST4b` (turn-start publish failure) with the rejection-only error pattern adopted for `AIT-ST5c` and `AIT-ST7b` in [PR #449](https://github.com/ably/specification/pull/449).

## Context

PR #449 reworked server-transport error handling so that awaited lifecycle methods surface publish failures via promise rejection only, with an `Ably.ErrorInfo(TurnLifecycleError)` wrapping the underlying error as `cause`. The per-turn `onError` callback is reserved for paths with no other signal — `streamResponse` stream errors (`AIT-ST6b3`) and `onCancel` handler failures (`AIT-ST9a`).

`AIT-ST4b` still carried the pre-existing "invoke `onError` and re-throw" wording. That was intentionally left out of PR #449's scope to keep it focused on what its branch name declared; this PR is the promised follow-up.

## Change

| Spec point | Change |
|---|---|
| `AIT-ST4b` | Turn-start publish failure must reject with an `Ably.ErrorInfo` (code `TurnLifecycleError`) wrapping the underlying error as `cause`. `onError` is not invoked. |

Wording now matches `AIT-ST5c` and `AIT-ST7b` verbatim in structure.

## Test plan

- [ ] Reads consistently with `AIT-ST5c` and `AIT-ST7b` (same pattern, same phrasing)
- [ ] No remaining "invoke `onError` and re-throw" references in `specifications/ai-transport-features.md`
- [ ] Companion implementation PR in `ably-ai-transport-js` already removed `onError` from `start()`'s catch block, so no code change is blocked on this

🤖 Generated with [Claude Code](https://claude.com/claude-code)