### PR TITLE
Fix some leftover references to Textile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,15 +39,15 @@ by adding a local development HTTP server.
 
 ## Features Spec Points
 
-When making changes to [the spec](textile/features.textile), please follow these guidelines:
+When making changes to [the spec](specifications/features.md), please follow these guidelines:
 
 - **Ordering**: Spec items should generally appear in ID order, but priority should be placed on ordering them in a way that makes coherent sense, even if that results in them being numbered out-of-order. For example, if `XXX1`, `XXX2` and `XXX3` exist but it would make more sense for `XXX3` to follow `XXX1`, then just move the spec items accordingly without changing their IDs
 - **Structuring**: When structuring the specification and defining the relationships between clauses and subclauses, generally avoid placing behavior descriptions and implementation details in the parent clause. The parent clause should primarily serve as an informational header for its subclauses. However, if it improves coherence, including behavior descriptions in the parent clause is permissible.
 - **Clarity**: Refrain from using conditional statements and multiple behavior descriptions within a single spec item. These should be separated into distinct subclauses for clarity.
 - **Addition**: When adding a new spec item, choose an ID that is greater than all others that exist in the given section, even if there is a gap in the currently assigned IDs.
 - **Modification**: Spec items should never be mutated, except to patch a mistake that doesn't change the semantics for SDK implementations. Follow the guidance outlined here in respect of _Replacement_ if the meaning or scope of a spec point needs to change.
-- **Removal**: When removing a spec item, it must remain but replace all text with `This clause has been deleted as of specification version @X.Y@.` (uses textile markup).
-- **Replacement**: When replacing a spec item, it must remain but replace all text with `This clause has been replaced by "@Z@":#Z as of specification version @X.Y@.` (uses textile markup).
+- **Removal**: When removing a spec item, it must remain but replace all text with `This clause has been deleted as of specification version X.Y.`.
+- **Replacement**: When replacing a spec item, it must remain but replace all text with ``This clause has been replaced by [`Z`](#Z) as of specification version X.Y.``.
 - **Deprecation**: Our approach to deprecating features is yet to be fully evolved and documented, however we have a current standard in place whereby the text "(deprecated)" is inserted at the beginning of a specification point to declare that it will be removed in a future release. The likely outcome is that in the next major release of the spec/protocol we'll remove that spec item, per guidance above.
 
 ### Additional Notes on Features Spec Point _Removal_ and _Replacement_
@@ -58,8 +58,8 @@ If the clause being removed or replaced has subclauses then the expected implica
 
 Variations on the replacement text for removed or replaced spec items is allowed, as long as the overarching structure remains the same. For example:
 
-- When a spec item has been removed because a new spec point has made it redundant, which is the case for `RTN15f` after specification version `1.2`, where the replacement text is: `This clause has been deleted (redundant to "RTN19a":#RTN19a) as of specification version @1.2@.`
-- When a spec item has been replaced by more than one new spec item, which is the case for `RTN16b` after specification version `1.2`, where the replacement text is: `This clause has been replaced by "@RTN16g@":#RTN16g and "@RTN16m@":#RTN16m as of specification version @1.2@.`
+- When a spec item has been removed because a new spec point has made it redundant, which is the case for `RTN15f` after specification version `1.2`, where the replacement text is: `This clause has been deleted (redundant to [RTN19a](#RTN19a)) as of specification version 1.2.`
+- When a spec item has been replaced by more than one new spec item, which is the case for `RTN16b` after specification version `1.2`, where the replacement text is: ``This clause has been replaced by [`RTN16g`](#RTN16g) and [`RTN16m`](#RTN16m) as of specification version 1.2.``
 
 Historically, before the above guidance was established - in particular around _Removal_ and _Replacement_ - there have been some cases where spec points were completely deleted.
 This left us open to the problem that client library references to spec items could end up semantically invalid if that spec point was re-used later.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Defined within the contents of this repository are multiple version numbers:
 
 | Version | Format | Location of Definition | Scope |
 | ------- | ------ | ---------------------- | ----- |
-| [**Specification**](#specification-version) | [SemVer](https://semver.org/) | The `versions.specification` field in [`meta.yaml`](meta.yaml) | Format and usage are specified in `CSV1`. The specification documents - files in [the `textile/` folder](textile/), the 'content'. |
+| [**Specification**](#specification-version) | [SemVer](https://semver.org/) | The `versions.specification` field in [`meta.yaml`](meta.yaml) | Format and usage are specified in `CSV1`. The specification documents - files in [the `specifications/` folder](specifications/), the 'content'. |
 | [**Protocol**](#protocol-version) | Integer from version `2` onwards (it was Decimal prior to that, for example `1.2`). | The `versions.protocol` field in [`meta.yaml`](meta.yaml) | Format and usage are specified in `CSV2`. The wire protocol used when communicating with the Ably service. Specified for REST requests under `RSC7a` and for Realtime connections under `RTN2f`. Sometimes referred to as 'API version' (when 'API' is referring to details of the protocols understood by the Ably service). |
 | [**Build**](#build-version) | [SemVer](https://semver.org/) | The `version` field in [`package.json`](package.json) | Other files hosted in this repository which render the specification for viewers or otherwise check it or build artifacts from it. |
 
@@ -37,10 +37,10 @@ Examples of changes that would result in a `minor` bump, being backwards compati
 Examples of changes that would result in a `patch` bump include:
 
 - Spelling mistake or typo corrections, where the meaning was previously clear and hasn't changed as a result of the fix
-- Formatting improvements in the textile markup, where those changes don't alter the way that the rendered output is interpreted
+- Formatting improvements in the markdown source, where those changes don't alter the way that the rendered output is interpreted
 - Improvements intended to make meaning clearer, where the intended meaning has not changed  - clearly these are changes that are likely to be subjective in nature, so it is suggested that these changes are rigorously reviewed by as many individuals as possible
 
-Where the 'SDK API' refers to the IDL and interface names documented in the [features spec](textile/features.textile),
+Where the 'SDK API' refers to the IDL and interface names documented in the [features spec](specifications/features.md),
 representing the surface area of the SDK that is directly visible to and used by app developers who are using that SDK to use the Ably service.
 
 It is expected that there may be specification changes which involve features spec point _Removal_, _Replacement_ or _Deprecation_ where that change only necessitates a `minor` bump to the specification version number - that is, the impact of the change is deemed backwards compatible according to the constraints outlined above. See [Contributing Guidance: Features Spec Points](CONTRIBUTING.md#features-spec-points).

--- a/build/package.json
+++ b/build/package.json
@@ -9,7 +9,7 @@
     "build:anchors": "./scripts/add-spec-anchors",
     "build:tailwind": "tailwindcss -i ./layouts/main.css -o ./public/tailwind.css --minify",
     "lint": "npm-run-all format:*:check",
-    "format:textile:check": "./scripts/find-duplicate-spec-items"
+    "format:markdown:check": "./scripts/find-duplicate-spec-items"
   },
   "repository": "ably/specification",
   "license": "Apache-2.0",

--- a/specifications/index.md
+++ b/specifications/index.md
@@ -80,5 +80,3 @@ All Ably client libraries at a minimum support [WebSockets](https://ably.com/top
 All client libraries share API documentation within this repository so that where possible, the documentation is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself). Where client libraries differ in regards to their API or usage, the language specific variations are documented in this repository, which in turn are replicated in the primary [Ably documentation](https://ably.com/docs).
 
 All client libraries developed or modified must reflect the changes to this documentation. You can fork this repository at <https://github.com/ably/docs> and issue a Pull Request.
-
-Read how to use our [Ably Textile format](/client-lib-development-guide/documentation-formatting-guide).


### PR DESCRIPTION
A few bits missed in the Markdown migration (which was merged in 57770ea).