### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -8,10 +8,13 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       deployments: write
       id-token: write
     steps:

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -18,22 +18,22 @@ jobs:
       deployments: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
-      - uses: ably/github-event-context-action@v1
+      - uses: ably/github-event-context-action@7f2c0aa105a3ee8c531919bdbe98f27c2d261bfe # v1.1.1
         id: context
 
       - name: Read Node.js version
         id: tool-versions
         run: echo "nodejs=$(grep nodejs .tool-versions | awk '{print $2}')" >> $GITHUB_OUTPUT
 
-      - uses: peaceiris/actions-hugo@v3
+      - uses: peaceiris/actions-hugo@6b1ee2dcc06c9b6629a5317fa0146473914d05e1 # v3
         with:
           hugo-version: 'latest'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ steps.tool-versions.outputs.nodejs }}
 
@@ -49,14 +49,14 @@ jobs:
           HUGO_PARAMS_BUILDCONTEXTTITLE: ${{ steps.context.outputs.title }}
 
       - if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-specification
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
       - if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: ably/sdk-upload-action@v2
+        uses: ably/sdk-upload-action@4e694297f208b72b5a9f6b1248a1556f19f821d6 # v2.2.0
         with:
           sourcePath: build/public
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -16,6 +16,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ably/github-event-context-action@v1
         id: context

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -22,7 +22,7 @@ jobs:
         id: tool-versions
         run: echo "nodejs=$(grep nodejs .tool-versions | awk '{print $2}')" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ steps.tool-versions.outputs.nodejs }}
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Read Node.js version
         id: tool-versions

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,9 +6,13 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflows in this repo, addressing findings from a workflow security audit. Changes are split into three commits, one per finding type:

- Disable credential persistence on `actions/checkout` steps so the default `GITHUB_TOKEN` is not left in the local git config after checkout.
- Scope each job's `GITHUB_TOKEN` permissions explicitly: top-level `permissions: {}`, with each job granted only the scopes it actually needs (`contents: read` for both, plus `deployments: write` / `id-token: write` for the build job's preview upload.
- Pin all third-party actions to commit SHAs (with the tag preserved as a trailing comment) so an upstream tag move can't silently change what runs in CI.

No behavioural changes intended — the workflows run the same checks against the same inputs.
