### PR TITLE
Rename `ValueType` classes to public LiveMap/LiveCounter

### DIFF
--- a/specifications/objects-features.md
+++ b/specifications/objects-features.md
@@ -20,7 +20,7 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
   - `(RTO23b)` This clause has been replaced by [RTO23e](#RTO23e)
   - `(RTO23e)` Perform the *ensure-active-channel* procedure ([RTL33](../features#RTL33)) on the underlying `RealtimeChannel`. If the procedure fails, the `get` function must reject with the same `ErrorInfo` that caused the procedure to fail
   - `(RTO23c)` If the [RTO17](#RTO17) sync state is not `SYNCED`, waits for the sync state to transition to `SYNCED`
-  - `(RTO23d)` Returns a new `PathObject` ([RTPO1](#RTPO1)) with `path` ([RTPO2a](#RTPO2a)) set to an empty list and `root` ([RTPO2b](#RTPO2b)) set to the `LiveMap` with id `root` from the internal `ObjectsPool`
+  - `(RTO23d)` Returns a new `PathObject` ([RTPO1](#RTPO1)) with `path` ([RTPO2a](#RTPO2a)) set to an empty list and `root` ([RTPO2b](#RTPO2b)) set to the `InternalLiveMap` with id `root` from the internal `ObjectsPool`
 - `(RTO11)` This clause has been replaced by [RTLMV3](#RTLMV3).
   - `(RTO11a)` This clause has been replaced by [RTLMV3](#RTLMV3).
     - `(RTO11a1)` This clause has been replaced by [RTLMV3](#RTLMV3).
@@ -137,16 +137,16 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
   - `(RTO26c)` If [`echoMessages`](../features#TO3h) client option is `false`, throw an `ErrorInfo` error with `statusCode` 400 and `code` 40000, indicating that `echoMessages` must be enabled for this operation
 - `(RTO3)` An internal `ObjectsPool` should be used to maintain the list of objects present on a channel
   - `(RTO3a)` `ObjectsPool` is a `Dict<String, LiveObject>` - a map of `LiveObject`s keyed by [`objectId`](../features#OST2a) string
-  - `(RTO3b)` It must always contain a `LiveMap` object with id `root`
-    - `(RTO3b1)` Upon initialization of the `ObjectsPool`, create a new `LiveMap` per [RTLM4](#RTLM4) with `objectId` set to `root` and add it to the `ObjectsPool`
+  - `(RTO3b)` It must always contain an `InternalLiveMap` object with id `root`
+    - `(RTO3b1)` Upon initialization of the `ObjectsPool`, create a new `InternalLiveMap` per [RTLM4](#RTLM4) with `objectId` set to `root` and add it to the `ObjectsPool`
 - `(RTO4)` When a channel `ATTACHED` `ProtocolMessage` is received, the client library must perform the following actions in order. The `ProtocolMessage` may contain a `HAS_OBJECTS` bit flag (see [TR3](../features#TR3)); note that some of the following actions are conditional on this flag.
   - `(RTO4c)` The [RTO17](#RTO17) sync state must transition to `SYNCING` if not already `SYNCING`
   - `(RTO4d)` The `bufferedObjectOperations` list must be cleared without applying any buffered operations
   - `(RTO4a)` If the `HAS_OBJECTS` flag is 1, the server will shortly perform an `OBJECT_SYNC` sequence as described in [RTO5](#RTO5). Note that this does not imply that objects are definitely present on the channel, only that there may be; the `OBJECT_SYNC` message may be empty
   - `(RTO4b)` If the `HAS_OBJECTS` flag is 0 or there is no `flags` field, the sync sequence must be considered complete immediately, and the client library must perform the following actions in order:
     - `(RTO4b1)` All objects except the one with id `root` must be removed from the internal `ObjectsPool`
-    - `(RTO4b2)` The data for the `LiveMap` with id `root` must be set to the value described in [RTLM4c](#RTLM4c). Note that the client SDK must not create a new `LiveMap` instance with id `root`; it must only clear the internal data of the existing `LiveMap` with id `root`
-      - `(RTO4b2a)` Emit a `LiveMapUpdate` object for the `LiveMap` with ID `root`, with `LiveMapUpdate.update` consisting of entries for the keys that were removed, each set to `removed`, and without populating `LiveMapUpdate.objectMessage`
+    - `(RTO4b2)` The data for the `InternalLiveMap` with id `root` must be set to the value described in [RTLM4c](#RTLM4c). Note that the client SDK must not create a new `InternalLiveMap` instance with id `root`; it must only clear the internal data of the existing `InternalLiveMap` with id `root`
+      - `(RTO4b2a)` Emit a `LiveMapUpdate` object for the `InternalLiveMap` with ID `root`, with `LiveMapUpdate.update` consisting of entries for the keys that were removed, each set to `removed`, and without populating `LiveMapUpdate.objectMessage`
     - `(RTO4b3)` The `SyncObjectsPool` must be cleared
     - `(RTO4b5)` This clause has been replaced by [RTO4d](#RTO4d)
     - `(RTO4b4)` Perform the actions for objects sync completion as described in [RTO5c](#RTO5c)
@@ -177,14 +177,14 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
         - `(RTO5c1a2)` Store the `LiveObjectUpdate` object returned by the operation, along with a reference to the updated object
       - `(RTO5c1b)` If an object with `ObjectState.objectId` does not exist in the internal `ObjectsPool`:
         - `(RTO5c1b1)` Create a new `LiveObject` using the data from `ObjectState` and add it to the internal `ObjectsPool`:
-          - `(RTO5c1b1a)` If `ObjectState.counter` is present, create a new `LiveCounter` per [RTLC4](#RTLC4) by passing in `ObjectState.objectId` as `objectId`, and then replace its internal data using the current `ObjectMessage` per [RTLC6](#RTLC6)
-          - `(RTO5c1b1b)` If `ObjectState.map` is present, create a new `LiveMap` per [RTLM4](#RTLM4) by passing in `ObjectState.objectId` as `objectId`, `ObjectState.map.semantics` as `semantics`, and then replace its internal data using the current `ObjectMessage` per [RTLM6](#RTLM6)
+          - `(RTO5c1b1a)` If `ObjectState.counter` is present, create a new `InternalLiveCounter` per [RTLC4](#RTLC4) by passing in `ObjectState.objectId` as `objectId`, and then replace its internal data using the current `ObjectMessage` per [RTLC6](#RTLC6)
+          - `(RTO5c1b1b)` If `ObjectState.map` is present, create a new `InternalLiveMap` per [RTLM4](#RTLM4) by passing in `ObjectState.objectId` as `objectId`, `ObjectState.map.semantics` as `semantics`, and then replace its internal data using the current `ObjectMessage` per [RTLM6](#RTLM6)
           - `(RTO5c1b1c)` This clause has been deleted (redundant to [RTO5f3](#RTO5f3)).
     - `(RTO5c2)` Remove any objects from the internal `ObjectsPool` for which `objectId`s were not received during the sync sequence
       - `(RTO5c2a)` The object with ID `root` must not be removed from `ObjectsPool`, as per [RTO3b](#RTO3b)
     - `(RTO5c10)` Rebuild every `parentReferences` map ([RTLO3f](#RTLO3f)):
       - `(RTO5c10a)` For each `LiveObject` in the internal `ObjectsPool`, reset its `parentReferences` to the initial value defined in [RTLO3f2](#RTLO3f2)
-      - `(RTO5c10b)` For each `LiveMap` in the internal `ObjectsPool`, iterate its `LiveMap#entries` ([RTLM11](#RTLM11)); for each entry whose value is a `LiveObject`, call `addParentReference(parent, key)` on that `LiveObject` per [RTLO4g](#RTLO4g), passing the `LiveMap` as `parent` and the entry's key as `key`
+      - `(RTO5c10b)` For each `InternalLiveMap` in the internal `ObjectsPool`, iterate its `InternalLiveMap#entries` ([RTLM11](#RTLM11)); for each entry whose value is a `LiveObject`, call `addParentReference(parent, key)` on that `LiveObject` per [RTLO4g](#RTLO4g), passing the `InternalLiveMap` as `parent` and the entry's key as `key`
     - `(RTO5c7)` For each previously existing object that was updated as a result of [RTO5c1a](#RTO5c1a), emit the corresponding stored `LiveObjectUpdate` object from [RTO5c1a2](#RTO5c1a2)
     - `(RTO5c6)` `ObjectMessages` stored in the `bufferedObjectOperations` list are applied as described in [RTO9](#RTO9), passing `source` as `CHANNEL`
     - `(RTO5c3)` Clear any stored sync sequence identifiers and cursor values
@@ -196,8 +196,8 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
   - `(RTO6a)` If an object with `objectId` exists in `ObjectsPool`, do not create a new object
   - `(RTO6b)` The expected type of the object can be inferred from the provided `objectId`:
     - `(RTO6b1)` Split the `objectId` (formatted as `[type]:[hash]&#64;[timestamp]`, see [RTO14c](#RTO14c)) on the separator `:` and parse the first part as the type string
-    - `(RTO6b2)` If the parsed type is `map`, create a new `LiveMap` per [RTLM4](#RTLM4) by passing in the `objectId`, and add it to the `ObjectsPool`
-    - `(RTO6b3)` If the parsed type is `counter`, create a new `LiveCounter` per [RTLC4](#RTLC4) by passing in the `objectId`, and add it to the `ObjectsPool`
+    - `(RTO6b2)` If the parsed type is `map`, create a new `InternalLiveMap` per [RTLM4](#RTLM4) by passing in the `objectId`, and add it to the `ObjectsPool`
+    - `(RTO6b3)` If the parsed type is `counter`, create a new `InternalLiveCounter` per [RTLC4](#RTLC4) by passing in the `objectId`, and add it to the `ObjectsPool`
 - `(RTO7)` The client library may receive `OBJECT` `ProtocolMessages` in realtime over the channel concurrently with `OBJECT_SYNC` `ProtocolMessages` during the object sync sequence ([RTO5](#RTO5)). Some of the incoming `OBJECT` messages may have already been applied to the objects described in the sync sequence, while others may not. Therefore, the client must buffer `OBJECT` messages during the sync sequence so that it can determine which of them should be applied to the objects once the sync is complete. See [RTO8](#RTO8)
   - `(RTO7a)` The `RealtimeObject` instance has an internal attribute `bufferedObjectOperations`, which is an array of `ObjectMessage` instances. This is used to store the buffered `ObjectMessages`, as described in [RTO8a](#RTO8a).
     - `(RTO7a1)` This array is empty upon `RealtimeObject` initialization
@@ -308,7 +308,7 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
         - `(RTO24b2a1)` The first (most-preferred) candidate is `pathToThis` itself
         - `(RTO24b2a2)` If the `LiveObjectUpdate` is a `LiveMapUpdate`, then for each key in `LiveMapUpdate.update`, append a further candidate consisting of `pathToThis` extended by that key
       - `(RTO24b2b)` For each registered subscription, find the first `eventPath` in `candidatePaths` that the subscription covers per [RTO24c1](#RTO24c1). If no such `eventPath` exists, do nothing for this subscription. Otherwise, call the subscription's listener exactly once with a `PathObjectSubscriptionEvent` that has:
-        - `(RTO24b2b1)` `object` - a new `PathObject` ([RTPO1](#RTPO1)) with `path` ([RTPO2a](#RTPO2a)) set to `eventPath` and `root` ([RTPO2b](#RTPO2b)) set to the `LiveMap` with id `root` from the internal `ObjectsPool`
+        - `(RTO24b2b1)` `object` - a new `PathObject` ([RTPO1](#RTPO1)) with `path` ([RTPO2a](#RTPO2a)) set to `eventPath` and `root` ([RTPO2b](#RTPO2b)) set to the `InternalLiveMap` with id `root` from the internal `ObjectsPool`
         - `(RTO24b2b2)` `message` - if `LiveObjectUpdate.objectMessage` is populated and its `operation` field is populated, a `PublicAPI::ObjectMessage` derived from `LiveObjectUpdate.objectMessage` per [PAOM3](#PAOM3); otherwise omitted
       - `(RTO24b2c)` If a listener throws an error, the error must be caught and logged without affecting the dispatch to other subscriptions, nor to other `pathToThis` iterations
   - `(RTO24c)` Subscription coverage:
@@ -334,8 +334,8 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
     - `(RTLO3d1)` Set to `false` when the `LiveObject` is initialized
   - `(RTLO3e)` protected `tombstonedAt` (optional) Time - a timestamp indicating when this object was tombstoned. This property is nullable, and specification points that manipulate this value maintain the invariant that it is non-null if and only if `isTombstone` is `true`
     - `(RTLO3e1)` Set to undefined/null when the `LiveObject` is initialized
-  - `(RTLO3f)` protected `parentReferences` `Dict<String, Set<String>>` - tracks which `LiveMap`s in the local `ObjectsPool` currently reference this `LiveObject`, and at which keys they do so. The mapping is keyed by the parent `LiveMap`'s `objectId`, with each value being the set of keys at which that `LiveMap` references this `LiveObject`. Used by `getFullPaths` ([RTLO4f](#RTLO4f)) to determine every path the object currently occupies in the LiveObjects graph
-    - `(RTLO3f1)` This mapping is keyed by `objectId` for consistency with the rest of the LiveObjects spec, where references between objects are stored as `objectId`s and resolved via the `ObjectsPool` on demand. Implementations may store a direct reference to the parent `LiveMap` instead — for example to avoid an `ObjectsPool` lookup at each step of `getFullPaths` ([RTLO4f](#RTLO4f)) traversal — provided the observable behaviour is unchanged. Such implementations should be aware that this may introduce reference cycles between `LiveMap`s, and must ensure this does not cause memory leaks
+  - `(RTLO3f)` protected `parentReferences` `Dict<String, Set<String>>` - tracks which `InternalLiveMap`s in the local `ObjectsPool` currently reference this `LiveObject`, and at which keys they do so. The mapping is keyed by the parent `InternalLiveMap`'s `objectId`, with each value being the set of keys at which that `InternalLiveMap` references this `LiveObject`. Used by `getFullPaths` ([RTLO4f](#RTLO4f)) to determine every path the object currently occupies in the LiveObjects graph
+    - `(RTLO3f1)` This mapping is keyed by `objectId` for consistency with the rest of the LiveObjects spec, where references between objects are stored as `objectId`s and resolved via the `ObjectsPool` on demand. Implementations may store a direct reference to the parent `InternalLiveMap` instead — for example to avoid an `ObjectsPool` lookup at each step of `getFullPaths` ([RTLO4f](#RTLO4f)) traversal — provided the observable behaviour is unchanged. Such implementations should be aware that this may introduce reference cycles between `InternalLiveMap`s, and must ensure this does not cause memory leaks
     - `(RTLO3f2)` Set to an empty map when the `LiveObject` is initialized
 - `(RTLO4)` `LiveObject` methods:
   - `(RTLO4b)` `subscribe` - subscribes a user to data updates on this `LiveObject` instance
@@ -373,7 +373,7 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
     - `(RTLO4a4)` Get the `siteSerial` value stored for this `LiveObject` in the `siteTimeserials` map using the key `ObjectMessage.siteCode`
     - `(RTLO4a5)` If the `siteSerial` for this `LiveObject` is null or an empty string, return true
     - `(RTLO4a6)` If the `siteSerial` for this `LiveObject` is not an empty string, return true if `ObjectMessage.serial` is greater than `siteSerial` when compared lexicographically
-  - `(RTLO4g)` internal `addParentReference(parent, key)` method - records that the `LiveMap` `parent` references this `LiveObject` at `key`
+  - `(RTLO4g)` internal `addParentReference(parent, key)` method - records that the `InternalLiveMap` `parent` references this `LiveObject` at `key`
     - `(RTLO4g1)` If `parentReferences` already contains an entry whose key is `parent.objectId`, add `key` to that entry's set
     - `(RTLO4g2)` Otherwise, insert into `parentReferences` a new entry whose key is `parent.objectId` and whose value is a set containing only `key`
   - `(RTLO4h)` internal `removeParentReference(parent, key)` method - removes the recorded reference from `parent` at `key`
@@ -388,15 +388,15 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
       - `(RTLO4e3a)` This clause has been replaced by [RTLO6a](#RTLO6a)
       - `(RTLO4e3b)` This clause has been replaced by [RTLO6b](#RTLO6b)
         - `(RTLO4e3b1)` This clause has been replaced by [RTLO6b1](#RTLO6b1)
-    - `(RTLO4e9)` If the `LiveObject` is a `LiveMap`, then before `LiveMap.data` is reset per [RTLO4e4](#RTLO4e4), for each `ObjectsMapEntry` in `LiveMap.data`:
+    - `(RTLO4e9)` If the `LiveObject` is an `InternalLiveMap`, then before `InternalLiveMap.data` is reset per [RTLO4e4](#RTLO4e4), for each `ObjectsMapEntry` in `InternalLiveMap.data`:
       - `(RTLO4e9a)` If `ObjectsMapEntry.data.objectId` is populated, fetch the object with this `objectId` from the `ObjectsPool`
-      - `(RTLO4e9b)` If the [`RTLO4e9a`](#RTLO4e9a) fetch returned an object, call its [`RTLO4h`](#RTLO4h) `removeParentReference(parent, key)` method, passing this `LiveMap` as `parent` and the iterated entry's key as `key`
+      - `(RTLO4e9b)` If the [`RTLO4e9a`](#RTLO4e9a) fetch returned an object, call its [`RTLO4h`](#RTLO4h) `removeParentReference(parent, key)` method, passing this `InternalLiveMap` as `parent` and the iterated entry's key as `key`
     - `(RTLO4e4)` Set the `data` attribute of the `LiveObject` to the value described in [RTLC4b](#RTLC4b) or [RTLM4c](#RTLM4c), depending on the object type
     - `(RTLO4e5)` Compute a `LiveObjectUpdate` representing the data change resulting from this `LiveObject` being tombstoned, by calculating the diff between the `data` value from before [RTLO4e4](#RTLO4e4) was applied (as `previousData`) and the current `data` value (as `newData`), per [RTLC14](#RTLC14) or [RTLM22](#RTLM22), depending on the object type
     - `(RTLO4e6)` Set `LiveObjectUpdate.tombstone` to `true` on the object computed in [RTLO4e5](#RTLO4e5)
     - `(RTLO4e7)` Set `LiveObjectUpdate.objectMessage` on the object computed in [RTLO4e5](#RTLO4e5) to the `ObjectMessage` argument
     - `(RTLO4e8)` Return the `LiveObjectUpdate` object computed in [RTLO4e5](#RTLO4e5)
-  - `(RTLO4f)` internal `getFullPaths` function - returns the list of all key-paths from the root `LiveMap` (objectId `root`) to this `LiveObject`. A *key-path* is a list of zero or more keys (the same concept as "path" elsewhere in this spec, e.g. on `PathObject`); we use the term key-path in this clause specifically to distinguish it from the graph-theoretical "simple path" used in [RTLO4f2](#RTLO4f2)
+  - `(RTLO4f)` internal `getFullPaths` function - returns the list of all key-paths from the root `InternalLiveMap` (objectId `root`) to this `LiveObject`. A *key-path* is a list of zero or more keys (the same concept as "path" elsewhere in this spec, e.g. on `PathObject`); we use the term key-path in this clause specifically to distinguish it from the graph-theoretical "simple path" used in [RTLO4f2](#RTLO4f2)
     - `(RTLO4f1)` Which key-paths are returned is determined via a directed graph G defined as follows. The nodes of G are the `LiveObject`s in the `ObjectsPool`. For each `(parent, key)` pair recorded in `child`'s `parentReferences` ([RTLO3f](#RTLO3f)), G has a directed edge from `parent` to `child` labelled `key`
     - `(RTLO4f2)` A *simple path* in G is a sequence of edges visiting each node at most once. Each such path in G from `root` to this `LiveObject` contributes one key-path to the returned list: the list of its edge labels. The empty simple path (which exists only when this `LiveObject` is itself `root`) contributes the empty key-path `[]`
     - `(RTLO4f3)` Each such key-path appears in the returned list exactly once. The order is unspecified
@@ -411,23 +411,23 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
   - `(RTLO6b)` Otherwise, it is equal to the current time using the local clock
     - `(RTLO6b1)` Log a debug or trace message indicating that `serialTimestamp` was not provided and the local clock is being used instead for the tombstone timestamp
 
-### LiveCounter
+### InternalLiveCounter
 
-- `(RTLC1)` The `LiveCounter` extends `LiveObject`
+- `(RTLC1)` The `InternalLiveCounter` extends `LiveObject`
 - `(RTLC2)` Represents the counter object type for Object IDs of type `counter`
 - `(RTLC3)` Holds a 64-bit floating-point number as a private `data`
-- `(RTLC4)` A new empty `LiveCounter` can be created with the following values:
+- `(RTLC4)` A new empty `InternalLiveCounter` can be created with the following values:
   - `(RTLC4a)` `objectId` is passed into the constructor and set upon creation
   - `(RTLC4b)` `data` is set to 0
-- `(RTLC11)` Data updates for a `LiveCounter` are emitted using the `LiveCounterUpdate` object:
+- `(RTLC11)` Data updates for an `InternalLiveCounter` are emitted using the `LiveCounterUpdate` object:
   - `(RTLC11a)` `LiveCounterUpdate` extends `LiveObjectUpdate`
   - `(RTLC11b)` `LiveCounterUpdate.update` has the following properties:
     - `(RTLC11b1)` `amount` number - the value by which the counter was incremented or decremented
-- `(RTLC5)` `LiveCounter#value` function:
+- `(RTLC5)` `InternalLiveCounter#value` function:
   - `(RTLC5a)` This clause has been replaced by [RTO25](#RTO25); the access API preconditions are now checked by callers
   - `(RTLC5b)` This clause has been replaced by [RTO25](#RTO25); the access API preconditions are now checked by callers
   - `(RTLC5c)` Returns the current `data` value
-- `(RTLC12)` `LiveCounter#increment` function:
+- `(RTLC12)` `InternalLiveCounter#increment` function:
   - `(RTLC12a)` Expects the following arguments:
     - `(RTLC12a1)` `amount` `Number` - the amount by which to increment the counter value
   - `(RTLC12b)` This clause has been replaced by [RTO26](#RTO26); the write API preconditions are now checked by callers
@@ -436,39 +436,39 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
   - `(RTLC12e)` Creates an `ObjectMessage` for a `COUNTER_INC` action in the following way:
     - `(RTLC12e1)` If `amount` is null, not of type `Number`, not a finite number, or omitted, the library should throw an `ErrorInfo` error with `statusCode` 400 and `code` 40003, indicating that `amount` must be a valid number
     - `(RTLC12e2)` Set `ObjectMessage.operation.action` to `ObjectOperationAction.COUNTER_INC`
-    - `(RTLC12e3)` Set `ObjectMessage.operation.objectId` to the Object ID of this `LiveCounter`
+    - `(RTLC12e3)` Set `ObjectMessage.operation.objectId` to the Object ID of this `InternalLiveCounter`
     - `(RTLC12e4)` This clause has been replaced by [RTLC12e5](#RTLC12e5) as of specification version 6.0.0.
     - `(RTLC12e5)` Set `ObjectMessage.operation.counterInc.number` to the provided `amount` value
   - `(RTLC12f)` This clause has been replaced by [RTLC12g](#RTLC12g)
   - `(RTLC12g)` Publishes the `ObjectMessage` from [RTLC12e](#RTLC12e) using `RealtimeObject#publishAndApply` ([RTO20](#RTO20)), passing the `ObjectMessage` as a single element in the array
-- `(RTLC13)` `LiveCounter#decrement` function:
+- `(RTLC13)` `InternalLiveCounter#decrement` function:
   - `(RTLC13a)` Expects the following arguments:
     - `(RTLC13a1)` `amount` `Number` - the amount by which to decrement the counter value
-  - `(RTLC13b)` This is an alias for calling [`LiveCounter#increment`](#RTLC12) with a negative `amount` and must be implemented with the same behavior
-  - `(RTLC13c)` If the client library chooses to delegate to `LiveCounter#increment` with a negated `amount`, then in languages where negating a non-number may result in implicit type coercion, the `amount` argument must first be validated as described in [RTLC12e1](#RTLC12e1) before proceeding
-- `(RTLC6)` `LiveCounter`'s internal `data` can be replaced with the `ObjectState` from a provided `ObjectMessage` (which the caller must ensure has its `object` field populated; let `ObjectState` refer to `ObjectMessage.object`) in the following way:
-  - `(RTLC6a)` Replace the private `siteTimeserials` of the `LiveCounter` with the value from `ObjectState.siteTimeserials`
-  - `(RTLC6e)` If `LiveCounter.isTombstone` is `true`, finish processing the `ObjectState`
+  - `(RTLC13b)` This is an alias for calling [`InternalLiveCounter#increment`](#RTLC12) with a negative `amount` and must be implemented with the same behavior
+  - `(RTLC13c)` If the client library chooses to delegate to `InternalLiveCounter#increment` with a negated `amount`, then in languages where negating a non-number may result in implicit type coercion, the `amount` argument must first be validated as described in [RTLC12e1](#RTLC12e1) before proceeding
+- `(RTLC6)` `InternalLiveCounter`'s internal `data` can be replaced with the `ObjectState` from a provided `ObjectMessage` (which the caller must ensure has its `object` field populated; let `ObjectState` refer to `ObjectMessage.object`) in the following way:
+  - `(RTLC6a)` Replace the private `siteTimeserials` of the `InternalLiveCounter` with the value from `ObjectState.siteTimeserials`
+  - `(RTLC6e)` If `InternalLiveCounter.isTombstone` is `true`, finish processing the `ObjectState`
     - `(RTLC6e1)` Return a `LiveCounterUpdate` object with `LiveCounterUpdate.noop` set to `true`, indicating that no update was made to the object
-  - `(RTLC6f)` If `ObjectState.tombstone` is `true`, tombstone the current `LiveCounter` using [`LiveObject.tombstone`](#RTLO4e), passing in the `ObjectMessage`. Finish processing the `ObjectState`
+  - `(RTLC6f)` If `ObjectState.tombstone` is `true`, tombstone the current `InternalLiveCounter` using [`LiveObject.tombstone`](#RTLO4e), passing in the `ObjectMessage`. Finish processing the `ObjectState`
     - `(RTLC6f1)` This clause has been replaced by [RTLC6f2](#RTLC6f2) as of specification version 6.0.0.
     - `(RTLC6f2)` Return the `LiveCounterUpdate` returned by the `LiveObject.tombstone` call performed in [RTLC6f](#RTLC6f)
   - `(RTLC6g)` Store the current `data` value as `previousData` for use in [RTLC6h](#RTLC6h)
   - `(RTLC6b)` Set the private flag `createOperationIsMerged` to `false`
   - `(RTLC6c)` Set `data` to the value of `ObjectState.counter.count`, or to 0 if it does not exist
-  - `(RTLC6d)` If `ObjectState.createOp` is present, merge the initial value into the `LiveCounter` as described in [RTLC16](#RTLC16), passing in the `ObjectState.createOp` instance and the `ObjectMessage`. Discard the `LiveCounterUpdate` object returned by the merge operation
+  - `(RTLC6d)` If `ObjectState.createOp` is present, merge the initial value into the `InternalLiveCounter` as described in [RTLC16](#RTLC16), passing in the `ObjectState.createOp` instance and the `ObjectMessage`. Discard the `LiveCounterUpdate` object returned by the merge operation
     - `(RTLC6d1)` This clause has been replaced by [RTLC10a](#RTLC10a)
     - `(RTLC6d2)` This clause has been replaced by [RTLC10b](#RTLC10b)
   - `(RTLC6h)` Calculate the diff between `previousData` from [RTLC6g](#RTLC6g) and the current `data` per [RTLC14](#RTLC14), set `LiveCounterUpdate.objectMessage` on the resulting update to the provided `ObjectMessage`, and return the resulting `LiveCounterUpdate` object
-- `(RTLC7)` An `ObjectOperation` from `ObjectMessage.operation` can be applied to a `LiveCounter` by performing the following actions in order:
+- `(RTLC7)` An `ObjectOperation` from `ObjectMessage.operation` can be applied to an `InternalLiveCounter` by performing the following actions in order:
   - `(RTLC7f)` Expects the following arguments:
-    - `(RTLC7f1)` `ObjectMessage` - an `ObjectMessage` instance with an existing `ObjectMessage.operation` object, with `ObjectMessage.operation.objectId` matching the Object ID of this `LiveCounter`. This `ObjectMessage` represents the operation to be applied to this `LiveCounter`
+    - `(RTLC7f1)` `ObjectMessage` - an `ObjectMessage` instance with an existing `ObjectMessage.operation` object, with `ObjectMessage.operation.objectId` matching the Object ID of this `InternalLiveCounter`. This `ObjectMessage` represents the operation to be applied to this `InternalLiveCounter`
     - `(RTLC7f2)` `source` `ObjectsOperationSource` - the source of the operation (see [RTO22](#RTO22))
   - `(RTLC7g)` Returns a boolean indicating whether the operation was successfully applied
   - `(RTLC7a)` A client library may choose to implement this logic as a convenience method named `applyOperation`, which accepts the arguments described in [RTLC7f](#RTLC7f)
   - `(RTLC7b)` If `ObjectMessage.operation` cannot be applied based on the result of [`LiveObject.canApplyOperation`](#RTLO4a), log a debug or trace message indicating that the operation cannot be applied because its serial value is not newer than the object's, and discard the `ObjectMessage` without taking any further action. Return `false`
   - `(RTLC7c)` If `source` is `CHANNEL`, set the entry in the private `siteTimeserials` map at the key `ObjectMessage.siteCode` to equal `ObjectMessage.serial`
-  - `(RTLC7e)` If `LiveCounter.isTombstone` is `true`, the operation cannot be applied to the object. Finish processing the `ObjectMessage` without taking any further action. No data update event is emitted. Return `false`
+  - `(RTLC7e)` If `InternalLiveCounter.isTombstone` is `true`, the operation cannot be applied to the object. Finish processing the `ObjectMessage` without taking any further action. No data update event is emitted. Return `false`
   - `(RTLC7d)` The `ObjectMessage.operation.action` field (see [`ObjectOperationAction`](../features#OOP2)) determines the type of operation to apply:
     - `(RTLC7d1)` If `ObjectMessage.operation.action` is set to `COUNTER_CREATE`, apply the operation as described in [RTLC8](#RTLC8), passing in `ObjectMessage.operation` and `ObjectMessage`
       - `(RTLC7d1a)` Emit the `LiveCounterUpdate` object returned as a result of applying the operation
@@ -484,20 +484,20 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
       - `(RTLC7d4c)` Emit the `LiveCounterUpdate` object returned as a result of applying the operation
       - `(RTLC7d4b)` Return `true`
     - `(RTLC7d3)` Otherwise, log a warning that an object operation message with an unsupported action has been received, and discard the current `ObjectMessage` without taking any further action. No data update event is emitted. Return `false`
-- `(RTLC8)` A `COUNTER_CREATE` operation can be applied to a `LiveCounter` in the following way:
+- `(RTLC8)` A `COUNTER_CREATE` operation can be applied to an `InternalLiveCounter` in the following way:
   - `(RTLC8a)` Expects the following arguments:
     - `(RTLC8a1)` `ObjectOperation`
     - `(RTLC8a2)` `ObjectMessage` - the source `ObjectMessage` that contains the operation
-  - `(RTLC8d)` The return type is a `LiveCounterUpdate` object, which indicates the data update for this `LiveCounter`
-  - `(RTLC8b)` If the private flag `createOperationIsMerged` is `true`, log a debug or trace message indicating that the operation will not be applied because a `COUNTER_CREATE` operation has already been applied to this `LiveCounter`. Discard the operation without taking any further action, and return a `LiveCounterUpdate` object with `LiveCounterUpdate.noop` set to `true`, indicating that no update was made to the object
-  - `(RTLC8c)` Otherwise merge the initial value into the `LiveCounter` as described in [RTLC16](#RTLC16), passing in the `ObjectOperation` instance and the `ObjectMessage`
+  - `(RTLC8d)` The return type is a `LiveCounterUpdate` object, which indicates the data update for this `InternalLiveCounter`
+  - `(RTLC8b)` If the private flag `createOperationIsMerged` is `true`, log a debug or trace message indicating that the operation will not be applied because a `COUNTER_CREATE` operation has already been applied to this `InternalLiveCounter`. Discard the operation without taking any further action, and return a `LiveCounterUpdate` object with `LiveCounterUpdate.noop` set to `true`, indicating that no update was made to the object
+  - `(RTLC8c)` Otherwise merge the initial value into the `InternalLiveCounter` as described in [RTLC16](#RTLC16), passing in the `ObjectOperation` instance and the `ObjectMessage`
   - `(RTLC8e)` Return the `LiveCounterUpdate` object returned by [RTLC16](#RTLC16)
-- `(RTLC9)` A `COUNTER_INC` operation can be applied to a `LiveCounter` in the following way:
+- `(RTLC9)` A `COUNTER_INC` operation can be applied to an `InternalLiveCounter` in the following way:
   - `(RTLC9a)` Expects the following arguments:
     - `(RTLC9a1)` This clause has been replaced by [RTLC9a2](#RTLC9a2) as of specification version 6.0.0.
     - `(RTLC9a2)` `CounterInc`
     - `(RTLC9a3)` `ObjectMessage` - the source `ObjectMessage` that contains the operation
-  - `(RTLC9c)` The return type is a `LiveCounterUpdate` object, which indicates the data update for this `LiveCounter`
+  - `(RTLC9c)` The return type is a `LiveCounterUpdate` object, which indicates the data update for this `InternalLiveCounter`
   - `(RTLC9b)` This clause has been replaced by [RTLC9f](#RTLC9f) as of specification version 6.0.0.
   - `(RTLC9d)` This clause has been replaced by [RTLC9g](#RTLC9g) as of specification version 6.0.0.
   - `(RTLC9e)` This clause has been replaced by [RTLC9h](#RTLC9h) as of specification version 6.0.0.
@@ -509,38 +509,38 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
   - `(RTLC10b)` This clause has been replaced by [RTLC16b](#RTLC16b) as of specification version 6.0.0.
   - `(RTLC10c)` This clause has been replaced by [RTLC16c](#RTLC16c) as of specification version 6.0.0.
   - `(RTLC10d)` This clause has been replaced by [RTLC16d](#RTLC16d) as of specification version 6.0.0.
-- `(RTLC16)` The initial value from an `ObjectOperation` can be merged into this `LiveCounter` in the following way. Expects an `ObjectOperation` and an `ObjectMessage` (the source `ObjectMessage` that contains the operation) as arguments. Let `counterCreate` be `ObjectOperation.counterCreate` if present, else the `CounterCreate` from which `ObjectOperation.counterCreateWithObjectId` was derived (see [RTLCV4g5](#RTLCV4g5)):
+- `(RTLC16)` The initial value from an `ObjectOperation` can be merged into this `InternalLiveCounter` in the following way. Expects an `ObjectOperation` and an `ObjectMessage` (the source `ObjectMessage` that contains the operation) as arguments. Let `counterCreate` be `ObjectOperation.counterCreate` if present, else the `CounterCreate` from which `ObjectOperation.counterCreateWithObjectId` was derived (see [RTLCV4g5](#RTLCV4g5)):
   - `(RTLC16a)` Add `counterCreate.count` to `data`, if it exists
   - `(RTLC16b)` Set the private flag `createOperationIsMerged` to `true`
   - `(RTLC16c)` If `counterCreate.count` exists, return a `LiveCounterUpdate` object with `LiveCounterUpdate.update.amount` set to `counterCreate.count` and `LiveCounterUpdate.objectMessage` set to the provided `ObjectMessage`
   - `(RTLC16d)` If `counterCreate.count` does not exist, return a `LiveCounterUpdate` object with `LiveCounterUpdate.noop` set to `true`
-- `(RTLC14)` The diff between two `LiveCounter` data values can be calculated in the following way:
+- `(RTLC14)` The diff between two `InternalLiveCounter` data values can be calculated in the following way:
   - `(RTLC14a)` Expects the following arguments:
     - `(RTLC14a1)` `previousData` `Number` - the previous `data` value
     - `(RTLC14a2)` `newData` `Number` - the new `data` value
   - `(RTLC14b)` Return a `LiveCounterUpdate` object with `LiveCounterUpdate.update.amount` set to `newData - previousData`
 
-### LiveMap
+### InternalLiveMap
 
-- `(RTLM1)` The `LiveMap` extends `LiveObject`
+- `(RTLM1)` The `InternalLiveMap` extends `LiveObject`
 - `(RTLM2)` Represents the map object type for Object IDs of type `map`
 - `(RTLM3)` Holds a `Dict<String, ObjectsMapEntry>` as a private `data` map
-  - `(RTLM3a)` `ObjectsMapEntry` entries in a `LiveMap` have the following attributes in addition to those defined in [OME2](../features#OME2):
+  - `(RTLM3a)` `ObjectsMapEntry` entries in an `InternalLiveMap` have the following attributes in addition to those defined in [OME2](../features#OME2):
     - `(RTLM3a1)` `tombstonedAt` (optional) Time - a timestamp indicating when this map entry was tombstoned. This property is nullable, and specification points that manipulate this value maintain the invariant that it is non-null if and only if the corresponding `ObjectsMapEntry.tombstone` is `true`
 - `(RTLM25)` Holds a nullable private `clearTimeserial` string, initially `null`
-- `(RTLM4)` A new empty `LiveMap` can be created with the following values:
+- `(RTLM4)` A new empty `InternalLiveMap` can be created with the following values:
   - `(RTLM4a)` `objectId` is passed into the constructor and set upon creation
   - `(RTLM4b)` `semantics` may be passed into the constructor and set upon creation; if not provided, it defaults to [`ObjectsMapSemantics.LWW`](../features#OMP2)
   - `(RTLM4c)` `data` is set to an empty map
   - `(RTLM4d)` `clearTimeserial` is set to `null`
-- `(RTLM18)` Data updates for a `LiveMap` are emitted using the `LiveMapUpdate` object:
+- `(RTLM18)` Data updates for an `InternalLiveMap` are emitted using the `LiveMapUpdate` object:
   - `(RTLM18a)` `LiveMapUpdate` extends `LiveObjectUpdate`
-  - `(RTLM18b)` `LiveMapUpdate.update` is of type `Dict<String, 'updated' | 'removed'>` - a map of `LiveMap` keys that were either updated or removed, with the corresponding value indicating the type of change for each key
-- `(RTLM5)` `LiveMap#get` function:
+  - `(RTLM18b)` `LiveMapUpdate.update` is of type `Dict<String, 'updated' | 'removed'>` - a map of `InternalLiveMap` keys that were either updated or removed, with the corresponding value indicating the type of change for each key
+- `(RTLM5)` `InternalLiveMap#get` function:
   - `(RTLM5a)` Accepts a key of type String
   - `(RTLM5b)` This clause has been replaced by [RTO25](#RTO25); the access API preconditions are now checked by callers
   - `(RTLM5c)` This clause has been replaced by [RTO25](#RTO25); the access API preconditions are now checked by callers
-  - `(RTLM5e)` If `LiveMap.isTombstone` is `true`, return undefined/null
+  - `(RTLM5e)` If `InternalLiveMap.isTombstone` is `true`, return undefined/null
   - `(RTLM5d)` Returns the value from the current `data` at the specified key, as follows:
     - `(RTLM5d1)` If no `ObjectsMapEntry` exists at the key, return undefined/null
     - `(RTLM5d2)` If an `ObjectsMapEntry` exists at the key:
@@ -555,38 +555,38 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
         - `(RTLM5d2f3)` This clause has been replaced by [RTLM5d2h](#RTLM5d2h)
         - `(RTLM5d2f2)` Otherwise, return the object with id `objectId`
       - `(RTLM5d2g)` Otherwise, return undefined/null
-- `(RTLM10)` `LiveMap#size`:
+- `(RTLM10)` `InternalLiveMap#size`:
   - `(RTLM10a)` A method or property, depending on what is more idiomatic for the platform to use for a Map/Dictionary interface. For example, in JavaScript, this is a property similar to `Map.size` for the native `Map` class
   - `(RTLM10b)` This clause has been replaced by [RTO25](#RTO25); the access API preconditions are now checked by callers
   - `(RTLM10c)` This clause has been replaced by [RTO25](#RTO25); the access API preconditions are now checked by callers
   - `(RTLM10d)` Returns the number of non-tombstoned entries (per [RTLM14](#RTLM14)) in the internal `data` map
-- `(RTLM11)` `LiveMap#entries`:
+- `(RTLM11)` `InternalLiveMap#entries`:
   - `(RTLM11a)` A method or property, depending on what is more idiomatic for the platform to use for a Map/Dictionary interface. For example, in JavaScript, this is a method similar to `Map.entries()` for the native `Map` class
   - `(RTLM11b)` This clause has been replaced by [RTO25](#RTO25); the access API preconditions are now checked by callers
   - `(RTLM11c)` This clause has been replaced by [RTO25](#RTO25); the access API preconditions are now checked by callers
   - `(RTLM11d)` Returns key-value pairs from the internal `data` map:
     - `(RTLM11d1)` Pairs with tombstoned entries (per [RTLM14](#RTLM14)) are not returned
     - `(RTLM11d3)` `ObjectsMapEntry` values are mapped to user-facing values following the same procedure as in [RTLM5d2](#RTLM5d2)
-      - `(RTLM11d3a)` Note that if [RTLM5d2](#RTLM5d2) results in an `ObjectsMapEntry` being mapped to an undefined/null value, the corresponding key-value pair is still returned by this `LiveMap#entries` call
+      - `(RTLM11d3a)` Note that if [RTLM5d2](#RTLM5d2) results in an `ObjectsMapEntry` being mapped to an undefined/null value, the corresponding key-value pair is still returned by this `InternalLiveMap#entries` call
     - `(RTLM11d2)` The return type is idiomatic for the platform's analogous Map/Dictionary interface operation. For example, in JavaScript, it returns a map iterator object like the one returned by `Map.entries()` method for the native `Map` class
-- `(RTLM12)` `LiveMap#keys`:
+- `(RTLM12)` `InternalLiveMap#keys`:
   - `(RTLM12a)` A method or property, depending on what is more idiomatic for the platform to use for a Map/Dictionary interface. For example, in JavaScript, this is a method similar to `Map.keys()` for the native `Map` class
-  - `(RTLM12b)` The implementation is identical to `LiveMap#entries`, except that it returns only the keys from the internal `data` map
-- `(RTLM13)` `LiveMap#values`:
+  - `(RTLM12b)` The implementation is identical to `InternalLiveMap#entries`, except that it returns only the keys from the internal `data` map
+- `(RTLM13)` `InternalLiveMap#values`:
   - `(RTLM13a)` A method or property, depending on what is more idiomatic for the platform to use for a Map/Dictionary interface. For example, in JavaScript, this is a method similar to `Map.values()` for the native `Map` class
-  - `(RTLM13b)` The implementation is identical to `LiveMap#entries`, except that it returns only the values from the internal `data` map
-- `(RTLM20)` `LiveMap#set` function:
+  - `(RTLM13b)` The implementation is identical to `InternalLiveMap#entries`, except that it returns only the values from the internal `data` map
+- `(RTLM20)` `InternalLiveMap#set` function:
   - `(RTLM20a)` Expects the following arguments:
     - `(RTLM20a1)` `key` `String` - the key to set the value for
     - `(RTLM20a2)` This clause has been replaced by [RTLM20a3](#RTLM20a3).
-    - `(RTLM20a3)` `value` `Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounterValueType | LiveMapValueType` - the value to assign to the key
+    - `(RTLM20a3)` `value` `Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounter | LiveMap` - the value to assign to the key
   - `(RTLM20b)` This clause has been replaced by [RTO26](#RTO26); the write API preconditions are now checked by callers
   - `(RTLM20c)` This clause has been replaced by [RTO26](#RTO26); the write API preconditions are now checked by callers
   - `(RTLM20d)` This clause has been replaced by [RTO26](#RTO26); the write API preconditions are now checked by callers
   - `(RTLM20e)` Creates an `ObjectMessage` for a `MAP_SET` action in the following way:
     - `(RTLM20e1)` Validates the provided `key` and `value` in a similar way as described in [RTLMV4b](#RTLMV4b) and [RTLMV4c](#RTLMV4c)
     - `(RTLM20e2)` Set `ObjectMessage.operation.action` to `ObjectOperationAction.MAP_SET`
-    - `(RTLM20e3)` Set `ObjectMessage.operation.objectId` to the Object ID of this `LiveMap`
+    - `(RTLM20e3)` Set `ObjectMessage.operation.objectId` to the Object ID of this `InternalLiveMap`
     - `(RTLM20e4)` This clause has been replaced by [RTLM20e6](#RTLM20e6) as of specification version 6.0.0.
     - `(RTLM20e5)` This clause has been replaced by [RTLM20e7](#RTLM20e7) as of specification version 6.0.0.
       - `(RTLM20e5a)` This clause has been replaced by [RTLM20e7a](#RTLM20e7a) as of specification version 6.0.0.
@@ -598,7 +598,7 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
     - `(RTLM20e6)` Set `ObjectMessage.operation.mapSet.key` to the provided `key` value
     - `(RTLM20e7)` Set `ObjectMessage.operation.mapSet.value` depending on the type of the provided `value`:
       - `(RTLM20e7a)` This clause has been replaced by [RTLM20e7g](#RTLM20e7g).
-      - `(RTLM20e7g)` If the `value` is of type `LiveCounterValueType` or `LiveMapValueType`:
+      - `(RTLM20e7g)` If the `value` is of type `LiveCounter` or `LiveMap`:
         - `(RTLM20e7g1)` Evaluate the value type per [RTLCV4](#RTLCV4) or [RTLMV4](#RTLMV4) respectively. Collect all generated `ObjectMessages` into an ordered list — for [RTLCV4](#RTLCV4) the list contains the single returned `ObjectMessage`; for [RTLMV4](#RTLMV4) the list is the returned array
         - `(RTLM20e7g2)` Set `ObjectMessage.operation.mapSet.value.objectId` to the `objectId` from the final `ObjectMessage` in the list gathered in [`RTLM20e7g1`](#RTLM20e7g1) (which is the create operation for the `LiveObject` whose creation the value type represents)
       - `(RTLM20e7b)` If the `value` is of type `JsonArray` or `JsonObject`, set `ObjectMessage.operation.mapSet.value.json` to that value
@@ -609,9 +609,9 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
   - `(RTLM20f)` This clause has been replaced by [RTLM20g](#RTLM20g)
   - `(RTLM20g)` This clause has been replaced by [RTLM20h](#RTLM20h).
   - `(RTLM20h)` Publishes all `ObjectMessages` using `RealtimeObject#publishAndApply` ([RTO20](#RTO20)):
-    - `(RTLM20h1)` If the `value` is of type `LiveCounterValueType` or `LiveMapValueType`, the array contains the `*_CREATE` `ObjectMessages` collected in [RTLM20e7g1](#RTLM20e7g1) followed by the `MAP_SET` `ObjectMessage` from [RTLM20e](#RTLM20e)
+    - `(RTLM20h1)` If the `value` is of type `LiveCounter` or `LiveMap`, the array contains the `*_CREATE` `ObjectMessages` collected in [RTLM20e7g1](#RTLM20e7g1) followed by the `MAP_SET` `ObjectMessage` from [RTLM20e](#RTLM20e)
     - `(RTLM20h2)` Otherwise, the `MAP_SET` `ObjectMessage` from [RTLM20e](#RTLM20e) is passed as a single element in the array
-- `(RTLM21)` `LiveMap#remove` function:
+- `(RTLM21)` `InternalLiveMap#remove` function:
   - `(RTLM21a)` Expects the following arguments:
     - `(RTLM21a1)` `key` `String` - the key to remove the value for
   - `(RTLM21b)` This clause has been replaced by [RTO26](#RTO26); the write API preconditions are now checked by callers
@@ -620,7 +620,7 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
   - `(RTLM21e)` Creates an `ObjectMessage` for a `MAP_REMOVE` action in the following way:
     - `(RTLM21e1)` Validates the provided `key` in a similar way as described in [RTLMV4b](#RTLMV4b)
     - `(RTLM21e2)` Set `ObjectMessage.operation.action` to `ObjectOperationAction.MAP_REMOVE`
-    - `(RTLM21e3)` Set `ObjectMessage.operation.objectId` to the Object ID of this `LiveMap`
+    - `(RTLM21e3)` Set `ObjectMessage.operation.objectId` to the Object ID of this `InternalLiveMap`
     - `(RTLM21e4)` This clause has been replaced by [RTLM21e5](#RTLM21e5) as of specification version 6.0.0.
     - `(RTLM21e5)` Set `ObjectMessage.operation.mapRemove.key` to the provided `key` value
   - `(RTLM21f)` This clause has been replaced by [RTLM21g](#RTLM21g)
@@ -629,11 +629,11 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
   - `(RTLM14a)` The method returns true if `ObjectsMapEntry.tombstone` is true
   - `(RTLM14c)` The method returns true if `ObjectsMapEntry.data.objectId` exists, there is an object in the local `ObjectsPool` with that id, and that `LiveObject.isTombstone` property is `true`
   - `(RTLM14b)` Otherwise, it returns false
-- `(RTLM6)` `LiveMap` internal `data` can be replaced with the `ObjectState` from a provided `ObjectMessage` (which the caller must ensure has its `object` field populated; let `ObjectState` refer to `ObjectMessage.object`) in the following way:
-  - `(RTLM6a)` Replace the private `siteTimeserials` of the `LiveMap` with the value from `ObjectState.siteTimeserials`
-  - `(RTLM6e)` If `LiveMap.isTombstone` is `true`, finish processing the `ObjectState`
+- `(RTLM6)` `InternalLiveMap` internal `data` can be replaced with the `ObjectState` from a provided `ObjectMessage` (which the caller must ensure has its `object` field populated; let `ObjectState` refer to `ObjectMessage.object`) in the following way:
+  - `(RTLM6a)` Replace the private `siteTimeserials` of the `InternalLiveMap` with the value from `ObjectState.siteTimeserials`
+  - `(RTLM6e)` If `InternalLiveMap.isTombstone` is `true`, finish processing the `ObjectState`
     - `(RTLM6e1)` Return a `LiveMapUpdate` object with `LiveMapUpdate.noop` set to `true`, indicating that no update was made to the object
-  - `(RTLM6f)` If `ObjectState.tombstone` is `true`, tombstone the current `LiveMap` using [`LiveObject.tombstone`](#RTLO4e), passing in the `ObjectMessage`. Finish processing the `ObjectState`
+  - `(RTLM6f)` If `ObjectState.tombstone` is `true`, tombstone the current `InternalLiveMap` using [`LiveObject.tombstone`](#RTLO4e), passing in the `ObjectMessage`. Finish processing the `ObjectState`
     - `(RTLM6f1)` This clause has been replaced by [RTLM6f2](#RTLM6f2) as of specification version 6.0.0.
     - `(RTLM6f2)` Return the `LiveMapUpdate` returned by the `LiveObject.tombstone` call performed in [RTLM6f](#RTLM6f)
   - `(RTLM6g)` Store the current `data` value as `previousData` for use in [RTLM6h](#RTLM6h)
@@ -644,21 +644,21 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
       - `(RTLM6c1a)` This clause has been replaced by [RTLO6a](#RTLO6a)
       - `(RTLM6c1b)` This clause has been replaced by [RTLO6b](#RTLO6b)
         - `(RTLM6c1b1)` This clause has been replaced by [RTLO6b1](#RTLO6b1)
-  - `(RTLM6d)` If `ObjectState.createOp` is present, merge the initial value into the `LiveMap` as described in [RTLM23](#RTLM23), passing in the `ObjectState.createOp` instance and the `ObjectMessage`. Discard the `LiveMapUpdate` object returned by the merge operation
+  - `(RTLM6d)` If `ObjectState.createOp` is present, merge the initial value into the `InternalLiveMap` as described in [RTLM23](#RTLM23), passing in the `ObjectState.createOp` instance and the `ObjectMessage`. Discard the `LiveMapUpdate` object returned by the merge operation
     - `(RTLM6d1)` This clause has been replaced by [RTLM17a](#RTLM17a)
       - `(RTLM6d1a)` This clause has been replaced by [RTLM17a1](#RTLM17a1)
       - `(RTLM6d1b)` This clause has been replaced by [RTLM17a2](#RTLM17a2)
     - `(RTLM6d2)` This clause has been replaced by [RTLM17b](#RTLM17b)
   - `(RTLM6h)` Calculate the diff between `previousData` from [RTLM6g](#RTLM6g) and the current `data` per [RTLM22](#RTLM22), set `LiveMapUpdate.objectMessage` on the resulting update to the provided `ObjectMessage`, and return the resulting `LiveMapUpdate` object
-- `(RTLM15)` An `ObjectOperation` from `ObjectMessage.operation` can be applied to a `LiveMap` by performing the following actions in order:
+- `(RTLM15)` An `ObjectOperation` from `ObjectMessage.operation` can be applied to an `InternalLiveMap` by performing the following actions in order:
   - `(RTLM15f)` Expects the following arguments:
-    - `(RTLM15f1)` `ObjectMessage` - an `ObjectMessage` instance with an existing `ObjectMessage.operation` object, with `ObjectMessage.operation.objectId` matching the Object ID of this `LiveMap`. This `ObjectMessage` represents the operation to be applied to this `LiveMap`
+    - `(RTLM15f1)` `ObjectMessage` - an `ObjectMessage` instance with an existing `ObjectMessage.operation` object, with `ObjectMessage.operation.objectId` matching the Object ID of this `InternalLiveMap`. This `ObjectMessage` represents the operation to be applied to this `InternalLiveMap`
     - `(RTLM15f2)` `source` `ObjectsOperationSource` - the source of the operation (see [RTO22](#RTO22))
   - `(RTLM15g)` Returns a boolean indicating whether the operation was successfully applied
   - `(RTLM15a)` A client library may choose to implement this logic as a convenience method named `applyOperation`, which accepts the arguments described in [RTLM15f](#RTLM15f)
   - `(RTLM15b)` If `ObjectMessage.operation` cannot be applied based on the result of [`LiveObject.canApplyOperation`](#RTLO4a), log a debug or trace message indicating that the operation cannot be applied because its serial value is not newer than the object's, and discard the `ObjectMessage` without taking any further action. Return `false`
   - `(RTLM15c)` If `source` is `CHANNEL`, set the entry in the private `siteTimeserials` map at the key `ObjectMessage.siteCode` to equal `ObjectMessage.serial`
-  - `(RTLM15e)` If `LiveMap.isTombstone` is `true`, the operation cannot be applied to the object. Finish processing the `ObjectMessage` without taking any further action. No data update event is emitted. Return `false`
+  - `(RTLM15e)` If `InternalLiveMap.isTombstone` is `true`, the operation cannot be applied to the object. Finish processing the `ObjectMessage` without taking any further action. No data update event is emitted. Return `false`
   - `(RTLM15d)` The `ObjectMessage.operation.action` field (see [`ObjectOperationAction`](../features#OOP2)) determines the type of operation to apply:
     - `(RTLM15d1)` If `ObjectMessage.operation.action` is set to `MAP_CREATE`, apply the operation as described in [RTLM16](#RTLM16), passing in `ObjectMessage.operation` and `ObjectMessage`
       - `(RTLM15d1a)` Emit the `LiveMapUpdate` object returned as a result of applying the operation
@@ -683,29 +683,29 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
       - `(RTLM15d8a)` Emit the `LiveMapUpdate` object returned as a result of applying the operation
       - `(RTLM15d8b)` Return `true`
     - `(RTLM15d4)` Otherwise, log a warning that an object operation message with an unsupported action has been received, and discard the current `ObjectMessage` without taking any further action. No data update event is emitted. Return `false`
-- `(RTLM16)` A `MAP_CREATE` operation can be applied to a `LiveMap` in the following way:
+- `(RTLM16)` A `MAP_CREATE` operation can be applied to an `InternalLiveMap` in the following way:
   - `(RTLM16a)` Expects the following arguments:
     - `(RTLM16a1)` `ObjectOperation`
     - `(RTLM16a2)` `ObjectMessage` - the source `ObjectMessage` that contains the operation
-  - `(RTLM16e)` The return type is a `LiveMapUpdate` object, which indicates the data update for this `LiveMap`
-  - `(RTLM16b)` If the private flag `createOperationIsMerged` is `true`, log a debug or trace message indicating that the operation will not be applied because a `MAP_CREATE` operation has already been applied to this `LiveMap`. Discard the operation without taking any further action, and return a `LiveMapUpdate` object with `LiveMapUpdate.noop` set to `true`, indicating that no update was made to the object
+  - `(RTLM16e)` The return type is a `LiveMapUpdate` object, which indicates the data update for this `InternalLiveMap`
+  - `(RTLM16b)` If the private flag `createOperationIsMerged` is `true`, log a debug or trace message indicating that the operation will not be applied because a `MAP_CREATE` operation has already been applied to this `InternalLiveMap`. Discard the operation without taking any further action, and return a `LiveMapUpdate` object with `LiveMapUpdate.noop` set to `true`, indicating that no update was made to the object
   - `(RTLM16c)` This clause has been deleted.
-  - `(RTLM16d)` Otherwise merge the initial value into the `LiveMap` as described in [RTLM23](#RTLM23), passing in the `ObjectOperation` instance and the `ObjectMessage`
+  - `(RTLM16d)` Otherwise merge the initial value into the `InternalLiveMap` as described in [RTLM23](#RTLM23), passing in the `ObjectOperation` instance and the `ObjectMessage`
   - `(RTLM16f)` Return the `LiveMapUpdate` object returned by [RTLM23](#RTLM23)
-- `(RTLM7)` A `MAP_SET` operation for a key can be applied to a `LiveMap` in the following way:
+- `(RTLM7)` A `MAP_SET` operation for a key can be applied to an `InternalLiveMap` in the following way:
   - `(RTLM7d)` Expects the following arguments:
     - `(RTLM7d1)` This clause has been replaced by [RTLM7d3](#RTLM7d3) as of specification version 6.0.0.
     - `(RTLM7d3)` `MapSet`
     - `(RTLM7d2)` `serial` string - operation's serial value
     - `(RTLM7d4)` `ObjectMessage` - the source `ObjectMessage` that contains the operation
-  - `(RTLM7e)` The return type is a `LiveMapUpdate` object, which indicates the data update for this `LiveMap`
+  - `(RTLM7e)` The return type is a `LiveMapUpdate` object, which indicates the data update for this `InternalLiveMap`
   - `(RTLM7h)` If the private `clearTimeserial` is non-null, and the provided `serial` is null or the `clearTimeserial` is lexicographically greater than or equal to `serial`, discard the operation without taking any action. Return a `LiveMapUpdate` object with `LiveMapUpdate.noop` set to `true`, indicating that no update was made to the object
   - `(RTLM7a)` If an `ObjectsMapEntry` exists in the private `data` for the specified key:
     - `(RTLM7a1)` If the operation cannot be applied to the existing entry as per [RTLM9](#RTLM9), discard the operation without taking any action. Return a `LiveMapUpdate` object with `LiveMapUpdate.noop` set to `true`, indicating that no update was made to the object
     - `(RTLM7a2)` Otherwise, apply the operation to the existing entry:
       - `(RTLM7a3)` Before `ObjectsMapEntry.data` is set per [RTLM7a2e](#RTLM7a2e):
         - `(RTLM7a3a)` If `ObjectsMapEntry.data.objectId` is populated, fetch the object with this `objectId` from the `ObjectsPool`
-        - `(RTLM7a3b)` If the [`RTLM7a3a`](#RTLM7a3a) fetch returned an object, call its [`RTLO4h`](#RTLO4h) `removeParentReference(parent, key)` method, passing this `LiveMap` as `parent` and the specified key as `key`
+        - `(RTLM7a3b)` If the [`RTLM7a3a`](#RTLM7a3a) fetch returned an object, call its [`RTLO4h`](#RTLO4h) `removeParentReference(parent, key)` method, passing this `InternalLiveMap` as `parent` and the specified key as `key`
       - `(RTLM7a2a)` This clause has been replaced by [RTLM7a2e](#RTLM7a2e) as of specification version 6.0.0.
       - `(RTLM7a2e)` Set `ObjectsMapEntry.data` to the `MapSet.value`
       - `(RTLM7a2b)` Set `ObjectsMapEntry.timeserial` to the provided `serial`
@@ -720,23 +720,23 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
     - `(RTLM7c1)` This clause has been replaced by [RTLM7g1](#RTLM7g1) as of specification version 6.0.0.
   - `(RTLM7g)` If `MapSet.value.objectId` is non-empty:
     - `(RTLM7g1)` Create a new `LiveObject` for this `objectId` in the internal `ObjectsPool` per [RTO6](#RTO6)
-    - `(RTLM7g2)` Call `addParentReference(parent, key)` per [RTLO4g](#RTLO4g) on the `LiveObject` from [RTLM7g1](#RTLM7g1), passing this `LiveMap` as `parent` and the specified key as `key`
+    - `(RTLM7g2)` Call `addParentReference(parent, key)` per [RTLO4g](#RTLO4g) on the `LiveObject` from [RTLM7g1](#RTLM7g1), passing this `InternalLiveMap` as `parent` and the specified key as `key`
   - `(RTLM7f)` Return a `LiveMapUpdate` object with a `LiveMapUpdate.update` map containing the key used in this operation set to `updated`, and `LiveMapUpdate.objectMessage` set to the provided `ObjectMessage`
-- `(RTLM8)` A `MAP_REMOVE` operation for a key can be applied to a `LiveMap` in the following way:
+- `(RTLM8)` A `MAP_REMOVE` operation for a key can be applied to an `InternalLiveMap` in the following way:
   - `(RTLM8c)` Expects the following arguments:
     - `(RTLM8c1)` This clause has been replaced by [RTLM8c4](#RTLM8c4) as of specification version 6.0.0.
     - `(RTLM8c4)` `MapRemove`
     - `(RTLM8c2)` `serial` string - operation's serial value
     - `(RTLM8c3)` `serialTimestamp` Time - operation's serial timestamp value
     - `(RTLM8c5)` `ObjectMessage` - the source `ObjectMessage` that contains the operation
-  - `(RTLM8d)` The return type is a `LiveMapUpdate` object, which indicates the data update for this `LiveMap`
+  - `(RTLM8d)` The return type is a `LiveMapUpdate` object, which indicates the data update for this `InternalLiveMap`
   - `(RTLM8g)` If the private `clearTimeserial` is non-null, and the provided `serial` is null or the `clearTimeserial` is lexicographically greater than or equal to `serial`, discard the operation without taking any action. Return a `LiveMapUpdate` object with `LiveMapUpdate.noop` set to `true`, indicating that no update was made to the object
   - `(RTLM8a)` If an `ObjectsMapEntry` exists in the private `data` for the specified key:
     - `(RTLM8a1)` If the operation cannot be applied to the existing entry as per [RTLM9](#RTLM9), discard the operation without taking any action. Return a `LiveMapUpdate` object with `LiveMapUpdate.noop` set to `true`, indicating that no update was made to the object
     - `(RTLM8a2)` Otherwise, apply the operation to the existing entry:
       - `(RTLM8a3)` Before `ObjectsMapEntry.data` is cleared per [RTLM8a2a](#RTLM8a2a):
         - `(RTLM8a3a)` If `ObjectsMapEntry.data.objectId` is populated, fetch the object with this `objectId` from the `ObjectsPool`
-        - `(RTLM8a3b)` If the [`RTLM8a3a`](#RTLM8a3a) fetch returned an object, call its [`RTLO4h`](#RTLO4h) `removeParentReference(parent, key)` method, passing this `LiveMap` as `parent` and the specified key as `key`
+        - `(RTLM8a3b)` If the [`RTLM8a3a`](#RTLM8a3a) fetch returned an object, call its [`RTLO4h`](#RTLO4h) `removeParentReference(parent, key)` method, passing this `InternalLiveMap` as `parent` and the specified key as `key`
       - `(RTLM8a2a)` Set `ObjectsMapEntry.data` to undefined/null
       - `(RTLM8a2b)` Set `ObjectsMapEntry.timeserial` to the provided `serial`
       - `(RTLM8a2c)` Set `ObjectsMapEntry.tombstone` to `true`
@@ -750,23 +750,23 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
     - `(RTLM8f2)` This clause has been replaced by [RTLO6b](#RTLO6b)
       - `(RTLM8f2a)` This clause has been replaced by [RTLO6b1](#RTLO6b1)
   - `(RTLM8e)` Return a `LiveMapUpdate` object with a `LiveMapUpdate.update` map containing the key used in this operation set to `removed`, and `LiveMapUpdate.objectMessage` set to the provided `ObjectMessage`
-- `(RTLM24)` A `MAP_CLEAR` operation can be applied to a `LiveMap` in the following way:
+- `(RTLM24)` A `MAP_CLEAR` operation can be applied to an `InternalLiveMap` in the following way:
   - `(RTLM24a)` Expects the following arguments:
     - `(RTLM24a1)` `serial` string - the operation's serial value
     - `(RTLM24a2)` `ObjectMessage` - the source `ObjectMessage` that contains the operation
-  - `(RTLM24b)` The return type is a `LiveMapUpdate` object, which indicates the data update for this `LiveMap`
+  - `(RTLM24b)` The return type is a `LiveMapUpdate` object, which indicates the data update for this `InternalLiveMap`
   - `(RTLM24c)` If the private `clearTimeserial` is non-null and is lexicographically greater than the provided `serial`, discard the operation without taking any action. Return a `LiveMapUpdate` object with `LiveMapUpdate.noop` set to `true`, indicating that no update was made to the object
   - `(RTLM24d)` Set the private `clearTimeserial` to the provided `serial`
   - `(RTLM24e)` For each `ObjectsMapEntry` in the internal `data`:
     - `(RTLM24e1)` If `ObjectsMapEntry.timeserial` is null or omitted, or the `serial` is lexicographically greater than `ObjectsMapEntry.timeserial`:
       - `(RTLM24e1c)` Before the `ObjectsMapEntry` is removed per [RTLM24e1a](#RTLM24e1a):
         - `(RTLM24e1c1)` If `ObjectsMapEntry.data.objectId` is populated, fetch the object with this `objectId` from the `ObjectsPool`
-        - `(RTLM24e1c2)` If the [`RTLM24e1c1`](#RTLM24e1c1) fetch returned an object, call its [`RTLO4h`](#RTLO4h) `removeParentReference(parent, key)` method, passing this `LiveMap` as `parent` and the iterated entry's key as `key`
+        - `(RTLM24e1c2)` If the [`RTLM24e1c1`](#RTLM24e1c1) fetch returned an object, call its [`RTLO4h`](#RTLO4h) `removeParentReference(parent, key)` method, passing this `InternalLiveMap` as `parent` and the iterated entry's key as `key`
       - `(RTLM24e1a)` Remove the entry from the internal `data` map. The entry is not retained as a tombstone.
       - `(RTLM24e1b)` Record the key for the `LiveMapUpdate` as `removed`
   - `(RTLM24f)` Return a `LiveMapUpdate` object with `LiveMapUpdate.update` containing each key recorded in [RTLM24e1b](#RTLM24e1b) set to `removed`, and `LiveMapUpdate.objectMessage` set to the provided `ObjectMessage`
 - `(RTLM9)` Whether a map operation can be applied to a map entry is determined as follows:
-  - `(RTLM9a)` For a `LiveMap` with `semantics` set to `ObjectsMapSemantics.LWW` (Last-Write-Wins CRDT semantics), the operation must only be applied if its serial is strictly greater ("after") than the entry's serial when compared lexicographically
+  - `(RTLM9a)` For an `InternalLiveMap` with `semantics` set to `ObjectsMapSemantics.LWW` (Last-Write-Wins CRDT semantics), the operation must only be applied if its serial is strictly greater ("after") than the entry's serial when compared lexicographically
   - `(RTLM9b)` If both the entry serial and the operation serial are null or empty strings, they are treated as the "earliest possible" serials and considered "equal", so the operation must not be applied
   - `(RTLM9c)` If only the entry serial exists and is not an empty string, the missing operation serial is considered lower than the existing entry serial, so the operation must not be applied
   - `(RTLM9d)` If only the operation serial exists and is not an empty string, it is considered greater than the missing entry serial, so the operation can be applied
@@ -777,16 +777,16 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
     - `(RTLM17a2)` This clause has been replaced by [RTLM23a2](#RTLM23a2) as of specification version 6.0.0.
   - `(RTLM17b)` This clause has been replaced by [RTLM23b](#RTLM23b) as of specification version 6.0.0.
   - `(RTLM17c)` This clause has been replaced by [RTLM23c](#RTLM23c) as of specification version 6.0.0.
-- `(RTLM23)` The initial value from an `ObjectOperation` can be merged into this `LiveMap` in the following way. Expects an `ObjectOperation` and an `ObjectMessage` (the source `ObjectMessage` that contains the operation) as arguments. Let `mapCreate` be `ObjectOperation.mapCreate` if present, else the `MapCreate` from which `ObjectOperation.mapCreateWithObjectId` was derived (see [RTLMV4j5](#RTLMV4j5)):
+- `(RTLM23)` The initial value from an `ObjectOperation` can be merged into this `InternalLiveMap` in the following way. Expects an `ObjectOperation` and an `ObjectMessage` (the source `ObjectMessage` that contains the operation) as arguments. Let `mapCreate` be `ObjectOperation.mapCreate` if present, else the `MapCreate` from which `ObjectOperation.mapCreateWithObjectId` was derived (see [RTLMV4j5](#RTLMV4j5)):
   - `(RTLM23a)` For each key-`ObjectsMapEntry` pair in `mapCreate.entries`:
     - `(RTLM23a1)` If `ObjectsMapEntry.tombstone` is `false` or omitted, apply the `MAP_SET` operation to the current key as described in [RTLM7](#RTLM7), passing in `ObjectsMapEntry.data` and the current key as `MapSet`, `ObjectsMapEntry.timeserial` as `serial`, and the `ObjectMessage`. Store the returned `LiveMapUpdate` object for use in [RTLM23c](#RTLM23c)
     - `(RTLM23a2)` If `ObjectsMapEntry.tombstone` is `true`, apply the `MAP_REMOVE` operation to the current key as described in [RTLM8](#RTLM8), passing in the current key as `MapRemove`, `ObjectsMapEntry.timeserial` as `serial`, `ObjectsMapEntry.serialTimestamp` as `serialTimestamp`, and the `ObjectMessage`. Store the returned `LiveMapUpdate` object for use in [RTLM23c](#RTLM23c)
   - `(RTLM23b)` Set the private flag `createOperationIsMerged` to `true`
   - `(RTLM23c)` Return a single `LiveMapUpdate` object, where `LiveMapUpdate.update` is a merged map containing all key-value pairs from the `LiveMapUpdate.update` maps of the stored `LiveMapUpdate` objects (skipping any stored `LiveMapUpdate` objects marked as no-op), and `LiveMapUpdate.objectMessage` is set to the provided `ObjectMessage`
-- `(RTLM19)` The `LiveMap` can be checked to determine whether it should release resources for its tombstoned `ObjectsMapEntry` entries as follows:
+- `(RTLM19)` The `InternalLiveMap` can be checked to determine whether it should release resources for its tombstoned `ObjectsMapEntry` entries as follows:
   - `(RTLM19a)` For each `ObjectsMapEntry` in the internal `data`:
     - `(RTLM19a1)` If `ObjectsMapEntry.tombstone` is `true`, and the difference between the current time and `ObjectsMapEntry.tombstonedAt` is greater than or equal to the [grace period](#RTO10b), remove the entry from the internal `data` map and release resources for the corresponding `ObjectsMapEntry` entity to allow it to be garbage collected
-- `(RTLM22)` The diff between two `LiveMap` data values can be calculated in the following way:
+- `(RTLM22)` The diff between two `InternalLiveMap` data values can be calculated in the following way:
   - `(RTLM22a)` Expects the following arguments:
     - `(RTLM22a1)` `previousData` `Dict<String, ObjectsMapEntry>` - the previous `data` value
     - `(RTLM22a2)` `newData` `Dict<String, ObjectsMapEntry>` - the new `data` value
@@ -795,27 +795,27 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
     - `(RTLM22b2)` For each key that exists in the non-tombstoned entries of `newData` but does not exist in the non-tombstoned entries of `previousData`, add the key to `LiveMapUpdate.update` with the value `updated`
     - `(RTLM22b3)` For each key that exists in the non-tombstoned entries of both `previousData` and `newData`, perform a deep comparison of the `data` attributes from `previousData` and `newData`. If the data values differ, add the key to `LiveMapUpdate.update` with the value `updated`
 
-### LiveCounterValueType
+### LiveCounter
 
-A `LiveCounterValueType` is an immutable blueprint for creating a new `LiveCounter` object. It stores the desired initial count value and is evaluated when passed to a mutation method such as `LiveMap#set` ([RTLM20](#RTLM20)) or as an entry value in `LiveMapValueType.create` ([RTLMV3](#RTLMV3)).
+A `LiveCounter` is an immutable blueprint for creating a new `InternalLiveCounter` object. It stores the desired initial count value and is evaluated when passed to a mutation method such as `InternalLiveMap#set` ([RTLM20](#RTLM20)) or as an entry value in `LiveMap.create` ([RTLMV3](#RTLMV3)).
 
-- `(RTLCV1)` `LiveCounterValueType` is an immutable value type representing the intent to create a new `LiveCounter` with a specific initial count
-- `(RTLCV2)` `LiveCounterValueType` has the following internal properties:
-  - `(RTLCV2a)` `count` `Number` - the initial count value for the `LiveCounter` to be created
-- `(RTLCV3)` `LiveCounterValueType.create` static factory function:
+- `(RTLCV1)` `LiveCounter` is an immutable value type representing the intent to create a new `InternalLiveCounter` with a specific initial count
+- `(RTLCV2)` `LiveCounter` has the following internal properties:
+  - `(RTLCV2a)` `count` `Number` - the initial count value for the `InternalLiveCounter` to be created
+- `(RTLCV3)` `LiveCounter.create` static factory function:
   - `(RTLCV3a)` Expects the following arguments:
-    - `(RTLCV3a1)` `initialCount` `Number` (optional) - the initial count for the new `LiveCounter` object. Defaults to 0
-  - `(RTLCV3b)` Returns a new `LiveCounterValueType` instance with the internal `count` set to the provided `initialCount` (or 0 if omitted)
+    - `(RTLCV3a1)` `initialCount` `Number` (optional) - the initial count for the new `InternalLiveCounter` object. Defaults to 0
+  - `(RTLCV3b)` Returns a new `LiveCounter` instance with the internal `count` set to the provided `initialCount` (or 0 if omitted)
   - `(RTLCV3c)` No input validation is performed at creation time. Validation is deferred to the evaluation procedure ([RTLCV4](#RTLCV4))
-  - `(RTLCV3d)` The returned `LiveCounterValueType` is immutable and must not be modified after creation
-- `(RTLCV4)` Internal evaluation procedure - when a `LiveCounterValueType` is evaluated by a mutation method (e.g. `LiveMap#set` or as an entry value during `LiveMapValueType` evaluation per [RTLMV4](#RTLMV4)), a `COUNTER_CREATE` `ObjectMessage` is generated as follows:
+  - `(RTLCV3d)` The returned `LiveCounter` is immutable and must not be modified after creation
+- `(RTLCV4)` Internal evaluation procedure - when a `LiveCounter` is evaluated by a mutation method (e.g. `InternalLiveMap#set` or as an entry value during `LiveMap` evaluation per [RTLMV4](#RTLMV4)), a `COUNTER_CREATE` `ObjectMessage` is generated as follows:
   - `(RTLCV4a)` If the internal `count` is not undefined and (is not of type `Number` or is not a finite number), the library should throw an `ErrorInfo` error with `statusCode` 400 and `code` 40003, indicating that the counter value must be a valid number
   - `(RTLCV4b)` Create a `CounterCreate` object:
     - `(RTLCV4b1)` Set `CounterCreate.count` to the internal `count` value, or to 0 if undefined
   - `(RTLCV4c)` Create an initial value JSON string by generating a JSON string representation of the `CounterCreate` object
   - `(RTLCV4d)` Create a unique string nonce with 16+ characters
   - `(RTLCV4e)` Get the current server time as described in [RTO16](#RTO16)
-  - `(RTLCV4f)` Create an `objectId` for the new `LiveCounter` as described in [RTO14](#RTO14), passing in `counter` as the `type`, the initial value JSON string from [RTLCV4c](#RTLCV4c), the nonce from [RTLCV4d](#RTLCV4d), and the server time from [RTLCV4e](#RTLCV4e)
+  - `(RTLCV4f)` Create an `objectId` for the new `InternalLiveCounter` as described in [RTO14](#RTO14), passing in `counter` as the `type`, the initial value JSON string from [RTLCV4c](#RTLCV4c), the nonce from [RTLCV4d](#RTLCV4d), and the server time from [RTLCV4e](#RTLCV4e)
   - `(RTLCV4g)` Create an `ObjectMessage` with:
     - `(RTLCV4g1)` `ObjectMessage.operation.action` set to `ObjectOperationAction.COUNTER_CREATE`
     - `(RTLCV4g2)` `ObjectMessage.operation.objectId` set to the `objectId` from [RTLCV4f](#RTLCV4f)
@@ -824,26 +824,26 @@ A `LiveCounterValueType` is an immutable blueprint for creating a new `LiveCount
     - `(RTLCV4g5)` The client library must retain the `CounterCreate` object from [RTLCV4b](#RTLCV4b) alongside the `CounterCreateWithObjectId`. It is the operation from which the `CounterCreateWithObjectId` was derived, and is needed for message size calculation ([OOP4k2](../features#OOP4k2)) and local application of the operation ([RTLC16](#RTLC16)). This `CounterCreate` is for local use only and must not be sent over the wire.
   - `(RTLCV4h)` Return the `ObjectMessage`
 
-### LiveMapValueType
+### LiveMap
 
-A `LiveMapValueType` is an immutable blueprint for creating a new `LiveMap` object. It stores the desired initial entries and is evaluated when passed to a mutation method such as `LiveMap#set` ([RTLM20](#RTLM20)) or as an entry value in another `LiveMapValueType.create` ([RTLMV3](#RTLMV3)) call. Supports arbitrarily deep nesting of `LiveMapValueType` and `LiveCounterValueType` values within entries.
+A `LiveMap` is an immutable blueprint for creating a new `InternalLiveMap` object. It stores the desired initial entries and is evaluated when passed to a mutation method such as `InternalLiveMap#set` ([RTLM20](#RTLM20)) or as an entry value in another `LiveMap.create` ([RTLMV3](#RTLMV3)) call. Supports arbitrarily deep nesting of `LiveMap` and `LiveCounter` values within entries.
 
-- `(RTLMV1)` `LiveMapValueType` is an immutable value type representing the intent to create a new `LiveMap` with specific initial entries
-- `(RTLMV2)` `LiveMapValueType` has the following internal properties:
-  - `(RTLMV2a)` `entries` `Dict<String, Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounterValueType | LiveMapValueType>` (optional) - the initial entries for the `LiveMap` to be created
-- `(RTLMV3)` `LiveMapValueType.create` static factory function:
+- `(RTLMV1)` `LiveMap` is an immutable value type representing the intent to create a new `InternalLiveMap` with specific initial entries
+- `(RTLMV2)` `LiveMap` has the following internal properties:
+  - `(RTLMV2a)` `entries` `Dict<String, Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounter | LiveMap>` (optional) - the initial entries for the `InternalLiveMap` to be created
+- `(RTLMV3)` `LiveMap.create` static factory function:
   - `(RTLMV3a)` Expects the following arguments:
-    - `(RTLMV3a1)` `entries` `Dict<String, Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounterValueType | LiveMapValueType>` (optional) - the initial entries for the new `LiveMap` object
-  - `(RTLMV3b)` Returns a new `LiveMapValueType` instance with the internal `entries` set to the provided `entries` (or undefined if omitted)
+    - `(RTLMV3a1)` `entries` `Dict<String, Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounter | LiveMap>` (optional) - the initial entries for the new `InternalLiveMap` object
+  - `(RTLMV3b)` Returns a new `LiveMap` instance with the internal `entries` set to the provided `entries` (or undefined if omitted)
   - `(RTLMV3c)` No input validation is performed at creation time. Validation is deferred to the evaluation procedure ([RTLMV4](#RTLMV4))
-  - `(RTLMV3d)` The returned `LiveMapValueType` is immutable and must not be modified after creation
-- `(RTLMV4)` Internal evaluation procedure - when a `LiveMapValueType` is evaluated by a mutation method (e.g. `LiveMap#set` or as an entry value during another `LiveMapValueType` evaluation), `ObjectMessages` are generated as follows:
+  - `(RTLMV3d)` The returned `LiveMap` is immutable and must not be modified after creation
+- `(RTLMV4)` Internal evaluation procedure - when a `LiveMap` is evaluated by a mutation method (e.g. `InternalLiveMap#set` or as an entry value during another `LiveMap` evaluation), `ObjectMessages` are generated as follows:
   - `(RTLMV4a)` If the internal `entries` is not undefined and (is null or is not of type `Dict`), the library should throw an `ErrorInfo` error with `statusCode` 400 and `code` 40003, indicating that entries must be a `Dict`
   - `(RTLMV4b)` If any of the keys in the internal `entries` are not of type `String`, the library should throw an `ErrorInfo` error with `statusCode` 400 and `code` 40003, indicating that keys must be `String`
   - `(RTLMV4c)` If any of the values in the internal `entries` are not of an expected type, the library should throw an `ErrorInfo` error with `statusCode` 400 and `code` 40013, indicating that such data type is unsupported
   - `(RTLMV4d)` Build entries for the `MapCreate` object. For each key-value pair in the internal `entries` (if present), create an `ObjectsMapEntry` for the value:
-    - `(RTLMV4d1)` If the value is of type `LiveCounterValueType`, evaluate it per [RTLCV4](#RTLCV4) to generate a `COUNTER_CREATE` `ObjectMessage`. Collect the generated `ObjectMessage` and set `ObjectsMapEntry.data.objectId` to the `objectId` from the `ObjectMessage`
-    - `(RTLMV4d2)` If the value is of type `LiveMapValueType`, recursively evaluate it per [RTLMV4](#RTLMV4) to generate an ordered array of `ObjectMessages`. Collect all generated `ObjectMessages` and set `ObjectsMapEntry.data.objectId` to the `objectId` from the final `ObjectMessage` in the array (which is the `MAP_CREATE` for the `LiveMap` whose creation this `LiveMapValueType` represents, per [RTLMV4k](#RTLMV4k); earlier entries create objects nested within it)
+    - `(RTLMV4d1)` If the value is of type `LiveCounter`, evaluate it per [RTLCV4](#RTLCV4) to generate a `COUNTER_CREATE` `ObjectMessage`. Collect the generated `ObjectMessage` and set `ObjectsMapEntry.data.objectId` to the `objectId` from the `ObjectMessage`
+    - `(RTLMV4d2)` If the value is of type `LiveMap`, recursively evaluate it per [RTLMV4](#RTLMV4) to generate an ordered array of `ObjectMessages`. Collect all generated `ObjectMessages` and set `ObjectsMapEntry.data.objectId` to the `objectId` from the final `ObjectMessage` in the array (which is the `MAP_CREATE` for the `InternalLiveMap` whose creation this `LiveMap` represents, per [RTLMV4k](#RTLMV4k); earlier entries create objects nested within it)
     - `(RTLMV4d3)` If the value is of type `JsonArray` or `JsonObject`, set `ObjectsMapEntry.data.json` to that value
     - `(RTLMV4d4)` If the value is of type `String`, set `ObjectsMapEntry.data.string` to that value
     - `(RTLMV4d5)` If the value is of type `Number`, set `ObjectsMapEntry.data.number` to that value
@@ -857,7 +857,7 @@ A `LiveMapValueType` is an immutable blueprint for creating a new `LiveMap` obje
     - `(RTLMV4f2)` Return a JSON string representation of the encoded `MapCreate` object
   - `(RTLMV4g)` Create a unique string nonce with 16+ characters
   - `(RTLMV4h)` Get the current server time as described in [RTO16](#RTO16)
-  - `(RTLMV4i)` Create an `objectId` for the new `LiveMap` as described in [RTO14](#RTO14), passing in `map` as the `type`, the initial value JSON string from [RTLMV4f](#RTLMV4f), the nonce from [RTLMV4g](#RTLMV4g), and the server time from [RTLMV4h](#RTLMV4h)
+  - `(RTLMV4i)` Create an `objectId` for the new `InternalLiveMap` as described in [RTO14](#RTO14), passing in `map` as the `type`, the initial value JSON string from [RTLMV4f](#RTLMV4f), the nonce from [RTLMV4g](#RTLMV4g), and the server time from [RTLMV4h](#RTLMV4h)
   - `(RTLMV4j)` Create an `ObjectMessage` with:
     - `(RTLMV4j1)` `ObjectMessage.operation.action` set to `ObjectOperationAction.MAP_CREATE`
     - `(RTLMV4j2)` `ObjectMessage.operation.objectId` set to the `objectId` from [RTLMV4i](#RTLMV4i)
@@ -868,21 +868,21 @@ A `LiveMapValueType` is an immutable blueprint for creating a new `LiveMap` obje
 
 ### PathObject
 
-A `PathObject` is a lazy, path-based reference into the LiveObjects graph. It stores a path (as an ordered list of string segments) from the root `LiveMap` and resolves it at the time each method is called. This means a `PathObject` survives object replacements: if the object at a given path changes (e.g. via a `MAP_SET` operation), the same `PathObject` will resolve to the new object on subsequent calls.
+A `PathObject` is a lazy, path-based reference into the LiveObjects graph. It stores a path (as an ordered list of string segments) from the root `InternalLiveMap` and resolves it at the time each method is called. This means a `PathObject` survives object replacements: if the object at a given path changes (e.g. via a `MAP_SET` operation), the same `PathObject` will resolve to the new object on subsequent calls.
 
-A `PathObject` is obtained from `RealtimeObject#get` ([RTO23](#RTO23)), which returns a `PathObject` rooted at the channel's root `LiveMap` with an empty path. Further `PathObjects` are obtained by navigating with `PathObject#get` or `PathObject#at`.
+A `PathObject` is obtained from `RealtimeObject#get` ([RTO23](#RTO23)), which returns a `PathObject` rooted at the channel's root `InternalLiveMap` with an empty path. Further `PathObjects` are obtained by navigating with `PathObject#get` or `PathObject#at`.
 
 - `(RTPO1)` The `PathObject` class provides a path-based view over the LiveObjects graph
   - `(RTPO1a)` A specific SDK implementation may choose to expose a subset of the methods available on the `PathObject` class based on the expected type at the path. For example, when the user provides a type structure as a generic type parameter to `RealtimeObject#get`, the SDK may use type-specific class names (e.g. `LiveMapPathObject`, `LiveCounterPathObject`, `PrimitivePathObject`) that only expose the methods applicable to that type. The specification describes the general `PathObject` class with the full set of methods
 - `(RTPO2)` `PathObject` has the following internal properties:
-  - `(RTPO2a)` `path` - an ordered list of string segments representing the path from the root `LiveMap` to this position in the graph
-  - `(RTPO2b)` `root` - a reference to the root `LiveMap` instance from the internal `ObjectsPool`
+  - `(RTPO2a)` `path` - an ordered list of string segments representing the path from the root `InternalLiveMap` to this position in the graph
+  - `(RTPO2b)` `root` - a reference to the root `InternalLiveMap` instance from the internal `ObjectsPool`
 - `(RTPO3)` Internal path resolution procedure - resolves the stored `path` against the LiveObjects graph:
   - `(RTPO3a)` Starting from `root`, walk through the path segments in order. For each segment:
-    - `(RTPO3a1)` The current object must be a `LiveMap`. If it is not, the resolution has failed
-    - `(RTPO3a2)` Look up the segment as a key in the current `LiveMap` using `LiveMap#get` ([RTLM5](#RTLM5)). If the result is undefined/null, the resolution has failed
+    - `(RTPO3a1)` The current object must be an `InternalLiveMap`. If it is not, the resolution has failed
+    - `(RTPO3a2)` Look up the segment as a key in the current `InternalLiveMap` using `InternalLiveMap#get` ([RTLM5](#RTLM5)). If the result is undefined/null, the resolution has failed
     - `(RTPO3a3)` The result becomes the current object for the next segment
-  - `(RTPO3b)` If the path is empty, the result is the `root` `LiveMap` itself
+  - `(RTPO3b)` If the path is empty, the result is the `root` `InternalLiveMap` itself
   - `(RTPO3c)` On resolution failure:
     - `(RTPO3c1)` For read operations (`value`, `instance`, `entries`, `keys`, `values`, `size`, `compact`, `compactJson`), return undefined/null. The client library may log a debug or trace message
     - `(RTPO3c2)` For write operations (`set`, `remove`, `increment`, `decrement`), the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92005, indicating that the path could not be resolved
@@ -905,82 +905,82 @@ A `PathObject` is obtained from `RealtimeObject#get` ([RTO23](#RTO23)), which re
 - `(RTPO7)` `PathObject#value` function:
   - `(RTPO7a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTPO7b)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3))
-  - `(RTPO7c)` If the resolved value is a `LiveCounter`, delegates to `LiveCounter#value` ([RTLC5](#RTLC5))
+  - `(RTPO7c)` If the resolved value is an `InternalLiveCounter`, delegates to `InternalLiveCounter#value` ([RTLC5](#RTLC5))
   - `(RTPO7d)` If the resolved value is a primitive (`Boolean`, `Binary`, `Number`, `String`, `JsonArray`, `JsonObject`), returns the value directly
-  - `(RTPO7e)` If the resolved value is a `LiveMap`, returns undefined/null
+  - `(RTPO7e)` If the resolved value is an `InternalLiveMap`, returns undefined/null
   - `(RTPO7f)` If path resolution fails, returns undefined/null per [RTPO3c1](#RTPO3c1)
 - `(RTPO8)` `PathObject#instance` function:
   - `(RTPO8a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTPO8b)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3))
-  - `(RTPO8c)` If the resolved value is a `LiveObject` (i.e. a `LiveMap` or `LiveCounter`), returns a new `Instance` ([RTINS1](#RTINS1)) wrapping that `LiveObject`
+  - `(RTPO8c)` If the resolved value is a `LiveObject` (i.e. an `InternalLiveMap` or `InternalLiveCounter`), returns a new `Instance` ([RTINS1](#RTINS1)) wrapping that `LiveObject`
   - `(RTPO8d)` If the resolved value is a primitive, returns undefined/null
   - `(RTPO8e)` If path resolution fails, returns undefined/null per [RTPO3c1](#RTPO3c1)
 - `(RTPO9)` `PathObject#entries` function:
   - `(RTPO9a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTPO9b)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3))
-  - `(RTPO9c)` If the resolved value is a `LiveMap`, delegates to `LiveMap#keys` ([RTLM12](#RTLM12)) and returns an array of `[key, PathObject]` pairs, where each `PathObject` is created as if by calling `PathObject#get` with the corresponding key on this `PathObject`
-  - `(RTPO9d)` If the resolved value is not a `LiveMap`, or if path resolution fails, returns an empty array
+  - `(RTPO9c)` If the resolved value is an `InternalLiveMap`, delegates to `InternalLiveMap#keys` ([RTLM12](#RTLM12)) and returns an array of `[key, PathObject]` pairs, where each `PathObject` is created as if by calling `PathObject#get` with the corresponding key on this `PathObject`
+  - `(RTPO9d)` If the resolved value is not an `InternalLiveMap`, or if path resolution fails, returns an empty array
 - `(RTPO10)` `PathObject#keys` function:
   - `(RTPO10a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTPO10b)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3))
-  - `(RTPO10c)` If the resolved value is a `LiveMap`, delegates to `LiveMap#keys` ([RTLM12](#RTLM12))
-  - `(RTPO10d)` If the resolved value is not a `LiveMap`, or if path resolution fails, returns an empty array
+  - `(RTPO10c)` If the resolved value is an `InternalLiveMap`, delegates to `InternalLiveMap#keys` ([RTLM12](#RTLM12))
+  - `(RTPO10d)` If the resolved value is not an `InternalLiveMap`, or if path resolution fails, returns an empty array
 - `(RTPO11)` `PathObject#values` function:
   - `(RTPO11a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTPO11b)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3))
-  - `(RTPO11c)` If the resolved value is a `LiveMap`, delegates to `LiveMap#keys` ([RTLM12](#RTLM12)) and returns an array of `PathObject`s, where each `PathObject` is created as if by calling `PathObject#get` with the corresponding key on this `PathObject`
-  - `(RTPO11d)` If the resolved value is not a `LiveMap`, or if path resolution fails, returns an empty array
+  - `(RTPO11c)` If the resolved value is an `InternalLiveMap`, delegates to `InternalLiveMap#keys` ([RTLM12](#RTLM12)) and returns an array of `PathObject`s, where each `PathObject` is created as if by calling `PathObject#get` with the corresponding key on this `PathObject`
+  - `(RTPO11d)` If the resolved value is not an `InternalLiveMap`, or if path resolution fails, returns an empty array
 - `(RTPO12)` `PathObject#size` function:
   - `(RTPO12a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTPO12b)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3))
-  - `(RTPO12c)` If the resolved value is a `LiveMap`, delegates to `LiveMap#size` ([RTLM10](#RTLM10))
-  - `(RTPO12d)` If the resolved value is not a `LiveMap`, or if path resolution fails, returns undefined/null
+  - `(RTPO12c)` If the resolved value is an `InternalLiveMap`, delegates to `InternalLiveMap#size` ([RTLM10](#RTLM10))
+  - `(RTPO12d)` If the resolved value is not an `InternalLiveMap`, or if path resolution fails, returns undefined/null
 - `(RTPO13)` `PathObject#compact` function:
   - `(RTPO13a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTPO13b)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3))
-  - `(RTPO13c)` If the resolved value is a `LiveMap`, returns a recursively compacted representation as a plain key-value object:
-    - `(RTPO13c1)` Each entry in the `LiveMap` is included in the result. Tombstoned entries are excluded
-    - `(RTPO13c2)` Nested `LiveMap` values are recursively compacted into nested plain key-value objects
-    - `(RTPO13c3)` Nested `LiveCounter` values are resolved to their numeric value
+  - `(RTPO13c)` If the resolved value is an `InternalLiveMap`, returns a recursively compacted representation as a plain key-value object:
+    - `(RTPO13c1)` Each entry in the `InternalLiveMap` is included in the result. Tombstoned entries are excluded
+    - `(RTPO13c2)` Nested `InternalLiveMap` values are recursively compacted into nested plain key-value objects
+    - `(RTPO13c3)` Nested `InternalLiveCounter` values are resolved to their numeric value
     - `(RTPO13c4)` Primitive values (`Boolean`, `Binary`, `Number`, `String`, `JsonArray`, `JsonObject`) are included as-is
-    - `(RTPO13c5)` Cyclic references (a `LiveMap` that has already been visited during this compaction) are represented by reusing the same in-memory object reference to the already-compacted result for that `LiveMap`
-  - `(RTPO13d)` If the resolved value is a `LiveCounter`, returns its current numeric value (equivalent to `PathObject#value`)
+    - `(RTPO13c5)` Cyclic references (an `InternalLiveMap` that has already been visited during this compaction) are represented by reusing the same in-memory object reference to the already-compacted result for that `InternalLiveMap`
+  - `(RTPO13d)` If the resolved value is an `InternalLiveCounter`, returns its current numeric value (equivalent to `PathObject#value`)
   - `(RTPO13e)` If the resolved value is a primitive, returns the value directly (equivalent to `PathObject#value`)
   - `(RTPO13f)` If path resolution fails, returns undefined/null per [RTPO3c1](#RTPO3c1)
 - `(RTPO14)` `PathObject#compactJson` function:
   - `(RTPO14a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTPO14b)` Behaves identically to `PathObject#compact` ([RTPO13](#RTPO13)) except for the following differences, which ensure the result is JSON-serializable:
     - `(RTPO14b1)` `Binary` values are encoded as base64 strings instead of being included as-is
-    - `(RTPO14b2)` Cyclic references are represented as an object with a single `objectId` property containing the Object ID of the referenced `LiveMap`, instead of reusing the in-memory object reference
+    - `(RTPO14b2)` Cyclic references are represented as an object with a single `objectId` property containing the Object ID of the referenced `InternalLiveMap`, instead of reusing the in-memory object reference
 - `(RTPO15)` `PathObject#set` function:
   - `(RTPO15a)` Expects the following arguments:
     - `(RTPO15a1)` `key` `String` - the key to set the value for
-    - `(RTPO15a2)` `value` - the value to assign to the key. Accepted types are the same as for `LiveMap#set` ([RTLM20](#RTLM20))
+    - `(RTPO15a2)` `value` - the value to assign to the key. Accepted types are the same as for `InternalLiveMap#set` ([RTLM20](#RTLM20))
   - `(RTPO15b)` Checks the write API preconditions per [RTO26](#RTO26)
   - `(RTPO15c)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3)). On failure, throws per [RTPO3c2](#RTPO3c2)
-  - `(RTPO15d)` If the resolved value is a `LiveMap`, delegates to `LiveMap#set` ([RTLM20](#RTLM20)) with the provided `key` and `value`
-  - `(RTPO15e)` If the resolved value is not a `LiveMap`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007, indicating that the operation is not supported for the resolved object type
+  - `(RTPO15d)` If the resolved value is an `InternalLiveMap`, delegates to `InternalLiveMap#set` ([RTLM20](#RTLM20)) with the provided `key` and `value`
+  - `(RTPO15e)` If the resolved value is not an `InternalLiveMap`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007, indicating that the operation is not supported for the resolved object type
 - `(RTPO16)` `PathObject#remove` function:
   - `(RTPO16a)` Expects the following arguments:
     - `(RTPO16a1)` `key` `String` - the key to remove the value for
   - `(RTPO16b)` Checks the write API preconditions per [RTO26](#RTO26)
   - `(RTPO16c)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3)). On failure, throws per [RTPO3c2](#RTPO3c2)
-  - `(RTPO16d)` If the resolved value is a `LiveMap`, delegates to `LiveMap#remove` ([RTLM21](#RTLM21)) with the provided `key`
-  - `(RTPO16e)` If the resolved value is not a `LiveMap`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
+  - `(RTPO16d)` If the resolved value is an `InternalLiveMap`, delegates to `InternalLiveMap#remove` ([RTLM21](#RTLM21)) with the provided `key`
+  - `(RTPO16e)` If the resolved value is not an `InternalLiveMap`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
 - `(RTPO17)` `PathObject#increment` function:
   - `(RTPO17a)` Expects the following arguments:
     - `(RTPO17a1)` `amount` `Number` (optional) - the amount by which to increment the counter value. Defaults to 1
   - `(RTPO17b)` Checks the write API preconditions per [RTO26](#RTO26)
   - `(RTPO17c)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3)). On failure, throws per [RTPO3c2](#RTPO3c2)
-  - `(RTPO17d)` If the resolved value is a `LiveCounter`, delegates to `LiveCounter#increment` ([RTLC12](#RTLC12)) with the provided `amount`
-  - `(RTPO17e)` If the resolved value is not a `LiveCounter`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
+  - `(RTPO17d)` If the resolved value is an `InternalLiveCounter`, delegates to `InternalLiveCounter#increment` ([RTLC12](#RTLC12)) with the provided `amount`
+  - `(RTPO17e)` If the resolved value is not an `InternalLiveCounter`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
 - `(RTPO18)` `PathObject#decrement` function:
   - `(RTPO18a)` Expects the following arguments:
     - `(RTPO18a1)` `amount` `Number` (optional) - the amount by which to decrement the counter value. Defaults to 1
   - `(RTPO18b)` Checks the write API preconditions per [RTO26](#RTO26)
   - `(RTPO18c)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3)). On failure, throws per [RTPO3c2](#RTPO3c2)
-  - `(RTPO18d)` If the resolved value is a `LiveCounter`, delegates to `LiveCounter#decrement` ([RTLC13](#RTLC13)) with the provided `amount`
-  - `(RTPO18e)` If the resolved value is not a `LiveCounter`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
+  - `(RTPO18d)` If the resolved value is an `InternalLiveCounter`, delegates to `InternalLiveCounter#decrement` ([RTLC13](#RTLC13)) with the provided `amount`
+  - `(RTPO18e)` If the resolved value is not an `InternalLiveCounter`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
 - `(RTPO19)` `PathObject#subscribe` function:
   - `(RTPO19a)` Expects the following arguments:
     - `(RTPO19a1)` `listener` - a callback function that receives a `PathObjectSubscriptionEvent` ([RTPO19e](#RTPO19e))
@@ -1009,31 +1009,31 @@ An `Instance` holds a direct reference to a specific resolved `LiveObject` or pr
   - `(RTINS3b)` If the wrapped value is a primitive, returns undefined/null
 - `(RTINS4)` `Instance#value` function:
   - `(RTINS4a)` Checks the access API preconditions per [RTO25](#RTO25)
-  - `(RTINS4b)` If the wrapped value is a `LiveCounter`, delegates to `LiveCounter#value` ([RTLC5](#RTLC5))
+  - `(RTINS4b)` If the wrapped value is an `InternalLiveCounter`, delegates to `InternalLiveCounter#value` ([RTLC5](#RTLC5))
   - `(RTINS4c)` If the wrapped value is a primitive (`Boolean`, `Binary`, `Number`, `String`, `JsonArray`, `JsonObject`), returns the value directly
-  - `(RTINS4d)` If the wrapped value is a `LiveMap`, returns undefined/null
+  - `(RTINS4d)` If the wrapped value is an `InternalLiveMap`, returns undefined/null
 - `(RTINS5)` `Instance#get` function:
   - `(RTINS5a)` Expects the following arguments:
     - `(RTINS5a1)` `key` `String` - the key to look up
   - `(RTINS5b)` Checks the access API preconditions per [RTO25](#RTO25)
-  - `(RTINS5c)` If the wrapped value is a `LiveMap`, looks up the value at `key` using `LiveMap#get` ([RTLM5](#RTLM5)) and returns a new `Instance` wrapping the result. If the result is undefined/null, returns undefined/null
-  - `(RTINS5d)` If the wrapped value is not a `LiveMap`, returns undefined/null
+  - `(RTINS5c)` If the wrapped value is an `InternalLiveMap`, looks up the value at `key` using `InternalLiveMap#get` ([RTLM5](#RTLM5)) and returns a new `Instance` wrapping the result. If the result is undefined/null, returns undefined/null
+  - `(RTINS5d)` If the wrapped value is not an `InternalLiveMap`, returns undefined/null
 - `(RTINS6)` `Instance#entries` function:
   - `(RTINS6a)` Checks the access API preconditions per [RTO25](#RTO25)
-  - `(RTINS6b)` If the wrapped value is a `LiveMap`, delegates to `LiveMap#entries` ([RTLM11](#RTLM11)) and returns an array of `[key, Instance]` pairs, where each `Instance` wraps the corresponding value
-  - `(RTINS6c)` If the wrapped value is not a `LiveMap`, returns an empty array
+  - `(RTINS6b)` If the wrapped value is an `InternalLiveMap`, delegates to `InternalLiveMap#entries` ([RTLM11](#RTLM11)) and returns an array of `[key, Instance]` pairs, where each `Instance` wraps the corresponding value
+  - `(RTINS6c)` If the wrapped value is not an `InternalLiveMap`, returns an empty array
 - `(RTINS7)` `Instance#keys` function:
   - `(RTINS7a)` Checks the access API preconditions per [RTO25](#RTO25)
-  - `(RTINS7b)` If the wrapped value is a `LiveMap`, delegates to `LiveMap#keys` ([RTLM12](#RTLM12))
-  - `(RTINS7c)` If the wrapped value is not a `LiveMap`, returns an empty array
+  - `(RTINS7b)` If the wrapped value is an `InternalLiveMap`, delegates to `InternalLiveMap#keys` ([RTLM12](#RTLM12))
+  - `(RTINS7c)` If the wrapped value is not an `InternalLiveMap`, returns an empty array
 - `(RTINS8)` `Instance#values` function:
   - `(RTINS8a)` Checks the access API preconditions per [RTO25](#RTO25)
-  - `(RTINS8b)` If the wrapped value is a `LiveMap`, delegates to `LiveMap#values` ([RTLM13](#RTLM13)) and returns an array of `Instance`s, where each `Instance` wraps the corresponding value
-  - `(RTINS8c)` If the wrapped value is not a `LiveMap`, returns an empty array
+  - `(RTINS8b)` If the wrapped value is an `InternalLiveMap`, delegates to `InternalLiveMap#values` ([RTLM13](#RTLM13)) and returns an array of `Instance`s, where each `Instance` wraps the corresponding value
+  - `(RTINS8c)` If the wrapped value is not an `InternalLiveMap`, returns an empty array
 - `(RTINS9)` `Instance#size` function:
   - `(RTINS9a)` Checks the access API preconditions per [RTO25](#RTO25)
-  - `(RTINS9b)` If the wrapped value is a `LiveMap`, delegates to `LiveMap#size` ([RTLM10](#RTLM10))
-  - `(RTINS9c)` If the wrapped value is not a `LiveMap`, returns undefined/null
+  - `(RTINS9b)` If the wrapped value is an `InternalLiveMap`, delegates to `InternalLiveMap#size` ([RTLM10](#RTLM10))
+  - `(RTINS9c)` If the wrapped value is not an `InternalLiveMap`, returns undefined/null
 - `(RTINS10)` `Instance#compact` function:
   - `(RTINS10a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTINS10b)` Behaves identically to `PathObject#compact` ([RTPO13](#RTPO13)), but operates on the wrapped value directly instead of resolving a path
@@ -1043,28 +1043,28 @@ An `Instance` holds a direct reference to a specific resolved `LiveObject` or pr
 - `(RTINS12)` `Instance#set` function:
   - `(RTINS12a)` Expects the following arguments:
     - `(RTINS12a1)` `key` `String` - the key to set the value for
-    - `(RTINS12a2)` `value` - the value to assign to the key. Accepted types are the same as for `LiveMap#set` ([RTLM20](#RTLM20))
+    - `(RTINS12a2)` `value` - the value to assign to the key. Accepted types are the same as for `InternalLiveMap#set` ([RTLM20](#RTLM20))
   - `(RTINS12b)` Checks the write API preconditions per [RTO26](#RTO26)
-  - `(RTINS12c)` If the wrapped value is a `LiveMap`, delegates to `LiveMap#set` ([RTLM20](#RTLM20)) with the provided `key` and `value`
-  - `(RTINS12d)` If the wrapped value is not a `LiveMap`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
+  - `(RTINS12c)` If the wrapped value is an `InternalLiveMap`, delegates to `InternalLiveMap#set` ([RTLM20](#RTLM20)) with the provided `key` and `value`
+  - `(RTINS12d)` If the wrapped value is not an `InternalLiveMap`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
 - `(RTINS13)` `Instance#remove` function:
   - `(RTINS13a)` Expects the following arguments:
     - `(RTINS13a1)` `key` `String` - the key to remove the value for
   - `(RTINS13b)` Checks the write API preconditions per [RTO26](#RTO26)
-  - `(RTINS13c)` If the wrapped value is a `LiveMap`, delegates to `LiveMap#remove` ([RTLM21](#RTLM21)) with the provided `key`
-  - `(RTINS13d)` If the wrapped value is not a `LiveMap`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
+  - `(RTINS13c)` If the wrapped value is an `InternalLiveMap`, delegates to `InternalLiveMap#remove` ([RTLM21](#RTLM21)) with the provided `key`
+  - `(RTINS13d)` If the wrapped value is not an `InternalLiveMap`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
 - `(RTINS14)` `Instance#increment` function:
   - `(RTINS14a)` Expects the following arguments:
     - `(RTINS14a1)` `amount` `Number` (optional) - the amount by which to increment the counter value. Defaults to 1
   - `(RTINS14b)` Checks the write API preconditions per [RTO26](#RTO26)
-  - `(RTINS14c)` If the wrapped value is a `LiveCounter`, delegates to `LiveCounter#increment` ([RTLC12](#RTLC12)) with the provided `amount`
-  - `(RTINS14d)` If the wrapped value is not a `LiveCounter`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
+  - `(RTINS14c)` If the wrapped value is an `InternalLiveCounter`, delegates to `InternalLiveCounter#increment` ([RTLC12](#RTLC12)) with the provided `amount`
+  - `(RTINS14d)` If the wrapped value is not an `InternalLiveCounter`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
 - `(RTINS15)` `Instance#decrement` function:
   - `(RTINS15a)` Expects the following arguments:
     - `(RTINS15a1)` `amount` `Number` (optional) - the amount by which to decrement the counter value. Defaults to 1
   - `(RTINS15b)` Checks the write API preconditions per [RTO26](#RTO26)
-  - `(RTINS15c)` If the wrapped value is a `LiveCounter`, delegates to `LiveCounter#decrement` ([RTLC13](#RTLC13)) with the provided `amount`
-  - `(RTINS15d)` If the wrapped value is not a `LiveCounter`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
+  - `(RTINS15c)` If the wrapped value is an `InternalLiveCounter`, delegates to `InternalLiveCounter#decrement` ([RTLC13](#RTLC13)) with the provided `amount`
+  - `(RTINS15d)` If the wrapped value is not an `InternalLiveCounter`, the library must throw an `ErrorInfo` error with `statusCode` 400 and `code` 92007
 - `(RTINS16)` `Instance#subscribe` function:
   - `(RTINS16a)` Expects the following arguments:
     - `(RTINS16a1)` `listener` - a callback function that receives an `InstanceSubscriptionEvent` ([RTINS16e](#RTINS16e)) when the wrapped object is updated
@@ -1161,8 +1161,8 @@ Types and their properties/methods are public and exposed to users by default. A
       canApplyOperation(ObjectMessage) -> Boolean // RTLO4a
       tombstone(ObjectMessage) -> LiveObjectUpdate // RTLO4e
       getFullPaths() -> String[][] // RTLO4f
-      addParentReference(LiveMap parent, String key) // RTLO4g
-      removeParentReference(LiveMap parent, String key) // RTLO4h
+      addParentReference(InternalLiveMap parent, String key) // RTLO4g
+      removeParentReference(InternalLiveMap parent, String key) // RTLO4h
       subscribe((LiveObjectUpdate) ->) -> Subscription // RTLO4b
 
     interface LiveObjectUpdate: // RTLO4b4, internal
@@ -1171,7 +1171,7 @@ Types and their properties/methods are public and exposed to users by default. A
       objectMessage: ObjectMessage? // RTLO4b4d
       tombstone: Boolean // RTLO4b4e
 
-    class LiveCounter extends LiveObject: // RTLC*, RTLC1, internal
+    class InternalLiveCounter extends LiveObject: // RTLC*, RTLC1, internal
       value() -> Number // RTLC5
       increment(Number amount) => io // RTLC12
       decrement(Number amount) => io // RTLC13
@@ -1179,26 +1179,26 @@ Types and their properties/methods are public and exposed to users by default. A
     interface LiveCounterUpdate extends LiveObjectUpdate: // RTLC11, RTLC11a, internal
       update: { amount: Number } // RTLC11b, RTLC11b1
 
-    class LiveMap extends LiveObject: // RTLM*, RTLM1, internal
+    class InternalLiveMap extends LiveObject: // RTLM*, RTLM1, internal
       clearTimeserial: String? // RTLM25
-      get(key: String) -> (Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounter | LiveMap)? // RTLM5
+      get(key: String) -> (Boolean | Binary | Number | String | JsonArray | JsonObject | InternalLiveCounter | InternalLiveMap)? // RTLM5
       size() -> Number // RTLM10
-      entries() -> [String, (Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounter | LiveMap)?][] // RTLM11
+      entries() -> [String, (Boolean | Binary | Number | String | JsonArray | JsonObject | InternalLiveCounter | InternalLiveMap)?][] // RTLM11
       keys() -> String[] // RTLM12
-      values() -> (Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounter | LiveMap)?[] // RTLM13
-      set(String key, (Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounterValueType | LiveMapValueType) value) => io // RTLM20
+      values() -> (Boolean | Binary | Number | String | JsonArray | JsonObject | InternalLiveCounter | InternalLiveMap)?[] // RTLM13
+      set(String key, (Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounter | LiveMap) value) => io // RTLM20
       remove(String key) => io // RTLM21
 
     interface LiveMapUpdate extends LiveObjectUpdate: // RTLM18, RTLM18a, internal
       update: Dict<String, 'updated' | 'removed'> // RTLM18b
 
-    class LiveCounterValueType: // RTLCV*
+    class LiveCounter: // RTLCV*
       count: Number // RTLCV2a, internal
-      static create(Number initialCount?) -> LiveCounterValueType // RTLCV3
+      static create(Number initialCount?) -> LiveCounter // RTLCV3
 
-    class LiveMapValueType: // RTLMV*
-      entries: Dict<String, (Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounterValueType | LiveMapValueType)>? // RTLMV2a, internal
-      static create(Dict<String, Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounterValueType | LiveMapValueType> entries?) -> LiveMapValueType // RTLMV3
+    class LiveMap: // RTLMV*
+      entries: Dict<String, (Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounter | LiveMap)>? // RTLMV2a, internal
+      static create(Dict<String, Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounter | LiveMap> entries?) -> LiveMap // RTLMV3
 
     interface PathObjectSubscriptionEvent: // RTPO19e
       object: PathObject // RTPO19e1
@@ -1246,7 +1246,7 @@ Types and their properties/methods are public and exposed to users by default. A
       size() -> Number? // RTPO12
       compact() -> Object? // RTPO13
       compactJson() -> Object? // RTPO14
-      set(String key, (Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounterValueType | LiveMapValueType) value) => io // RTPO15
+      set(String key, (Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounter | LiveMap) value) => io // RTPO15
       remove(String key) => io // RTPO16
       increment(Number amount?) => io // RTPO17
       decrement(Number amount?) => io // RTPO18
@@ -1262,7 +1262,7 @@ Types and their properties/methods are public and exposed to users by default. A
       size() -> Number? // RTINS9
       compact() -> Object? // RTINS10
       compactJson() -> Object? // RTINS11
-      set(String key, (Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounterValueType | LiveMapValueType) value) => io // RTINS12
+      set(String key, (Boolean | Binary | Number | String | JsonArray | JsonObject | LiveCounter | LiveMap) value) => io // RTINS12
       remove(String key) => io // RTINS13
       increment(Number amount?) => io // RTINS14
       decrement(Number amount?) => io // RTINS15


### PR DESCRIPTION
- We want to keep `LiveMap.create`/`LiveCounter.create` from `ably-js` to be in sync with other SDKs. Current changes make spec clear about `LiveMap` and `LiveCounter` types.
- Currently, couldn't find an easy way to do this, small tweaks will only make spec more confusing : (
- Rename existing spec `LiveMap` to `InternalLiveMap` and `LiveCounter` to `InternalLiveCounter`
- update spec `LiveMapValueType` to `LiveMap` and `LiveCounterValueType` to `LiveCounter`
- Based on discussion -> https://ably.atlassian.net/wiki/spaces/AI/pages/5127372801/Final+Assessment+of+the+LiveObjects+Path-Based+API+for+Java+and+Swift?focusedCommentId=5135794182

## Summary                                                                                                         

Renames the internal LiveObject classes so that the public, user-facing value-type names (`LiveMap`,`LiveCounter`)  are unqualified:
                                                                                                                     
| Old | New |                                                                                                      
|---|---|
| `LiveCounter` (internal class) | `InternalLiveCounter` |
| `LiveMap` (internal class) | `InternalLiveMap` |
| `LiveCounterValueType` (public blueprint) | `LiveCounter` |                                                        
| `LiveMapValueType` (public blueprint) | `LiveMap` |
                                                                                                                     
`LiveObject` base class and the `LiveCounterUpdate` / `LiveMapUpdate` interfaces are intentionally left unchanged.   
                                                                                                                     
## Motivation                                                                                                        
                                                                                                                   
ably-js currently exposes `LiveMap` / `LiveCounter` to users via TypeScript export aliases over the                 `LiveMapValueType` / `LiveCounterValueType` classes. Typed SDKs (Java, Swift, Python) cannot replicate this tric — the alias-based layering forces unnatural class names on their public API. Renaming the internal classes to
`InternalLive*` frees the unqualified names for the user-facing blueprint types, allowing every SDK to expose `LiveMap.create(...)` / `LiveCounter.create(...)` directly without alias indirection. Aligns with the `CONTRIBUTING.md` § "Public-API namespacing for name clashes" guidance.                                                                                           