### PR TITLE
docs(uts): proxy supports both JSON and msgpack, not text frames only

### DIFF
--- a/uts/docs/integration-testing.md
+++ b/uts/docs/integration-testing.md
@@ -246,7 +246,7 @@ Only tests on the **data path** need both protocols. These are tests where messa
 
 Tests for **connection lifecycle**, **authentication**, **channel attach/detach**, and other protocol-agnostic behaviours do not need protocol variants. These tests exercise control-plane operations whose correctness does not depend on the wire encoding of message payloads.
 
-**Proxy tests always use JSON.** The proxy only supports text WebSocket frames, so proxy-based tests cannot use msgpack.
+**Proxy tests may use either protocol.** As of [uts-proxy v0.3.0](https://github.com/ably/uts-proxy/releases/tag/v0.3.0), the proxy determines a WebSocket message's encoding from the `format` query parameter — matching the Ably server — instead of from the WebSocket frame type (text vs binary). It can therefore decode and match both JSON and msgpack messages, including SDKs that send JSON payloads over binary frames. Proxy data-path tests should follow the `## Protocol Variants` convention below; pin a test to JSON only when the SDK under test does not implement msgpack.
 
 ### Spec file convention
 


### PR DESCRIPTION
## Summary

Corrects the integration-testing policy doc, which incorrectly stated that the test proxy is limited to JSON / text WebSocket frames.

[`uts-proxy` v0.3.0](https://github.com/ably/uts-proxy/pull/4) changed the proxy to determine a WebSocket message's encoding from the **`format` query parameter** (mirroring the real Ably server) instead of from the WebSocket **frame type** (text vs binary). The proxy can now decode, match, and act on both JSON and msgpack messages.

## What was wrong

`uts/docs/integration-testing.md` claimed:

> **Proxy tests always use JSON.** The proxy only supports text WebSocket frames, so proxy-based tests cannot use msgpack.

This assumption (frame opcode ⇒ encoding) was never how the Ably server behaves, and it broke proxy frame-inspection in a non-obvious way: SDKs that send JSON payloads over **binary** WebSocket frames (e.g. ably-java, even with `useBinaryProtocol: false`) had their client→server frames logged by the proxy as unparseable (`{"_binary": true, "action": -1}`). Any proxy rule or assertion matching on a client-sent protocol-message `action` therefore silently failed, even though the SDK was behaving correctly and the real server accepted the frames.

## What changed

Updated the **Protocol Variants** section to reflect v0.3.0:
- The proxy decodes by the `format` query parameter, matching the server.
- Both JSON and msgpack are supported, including SDKs that send JSON over binary frames.
- Proxy data-path tests follow the normal `## Protocol Variants` convention; JSON is pinned only when the SDK under test does not implement msgpack (an SDK constraint, not a proxy one).

## References
- Proxy change: https://github.com/ably/uts-proxy/pull/4 (released as v0.3.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)