### PR TITLE
[AIT-1106] fix(uts): correct objects proxy specs and harden proxy rule/timeout guidance

### DIFF
--- a/uts/README.md
+++ b/uts/README.md
@@ -28,14 +28,13 @@ uts/
 │   │   ├── connection/                # RTN — connection management
 │   │   └── presence/                  # RTP — realtime presence
 │   └── integration/                   # Realtime integration tests
-│       ├── helpers/
-│       │   └── proxy.md               # Proxy infrastructure spec
 │       ├── proxy/                     # Proxy-based fault injection tests
 │       └── *.md                       # Direct sandbox tests
 ├── docs/                              # Guides and reference
 │   ├── writing-test-specs.md          # How to write UTS specs
 │   ├── writing-derived-tests.md       # How to translate specs into SDK tests
 │   ├── integration-testing.md         # Integration testing policy
+│   ├── proxy.md                       # Proxy infrastructure spec (cross-module)
 │   └── completion-status.md           # Spec coverage matrix
 └── README.md                          # This file
 ```
@@ -101,4 +100,4 @@ See [docs/writing-test-specs.md](docs/writing-test-specs.md) for the full pseudo
 
 The programmable proxy for integration testing lives in a separate repository: [ably/uts-proxy](https://github.com/ably/uts-proxy). It sits between the SDK and the Ably sandbox, transparently forwarding traffic while allowing rule-based fault injection.
 
-See `realtime/integration/helpers/proxy.md` for the proxy infrastructure specification used by test specs in this repository.
+See `docs/proxy.md` for the proxy infrastructure specification used by test specs in this repository.

--- a/uts/README.md
+++ b/uts/README.md
@@ -100,4 +100,4 @@ See [docs/writing-test-specs.md](docs/writing-test-specs.md) for the full pseudo
 
 The programmable proxy for integration testing lives in a separate repository: [ably/uts-proxy](https://github.com/ably/uts-proxy). It sits between the SDK and the Ably sandbox, transparently forwarding traffic while allowing rule-based fault injection.
 
-See `docs/proxy.md` for the proxy infrastructure specification used by test specs in this repository.
+See `uts/docs/proxy.md` for the proxy infrastructure specification used by test specs in this repository.

--- a/uts/docs/integration-testing.md
+++ b/uts/docs/integration-testing.md
@@ -149,7 +149,7 @@ AFTER ALL TESTS:
 
 ### Proxy Setup (integration-proxy only)
 
-Proxy tests additionally set up a proxy session per test or group of tests. See `docs/proxy.md` for the proxy infrastructure API.
+Proxy tests additionally set up a proxy session per test or group of tests. See `uts/docs/proxy.md` for the proxy infrastructure API.
 
 ```pseudo
 BEFORE EACH TEST:

--- a/uts/docs/integration-testing.md
+++ b/uts/docs/integration-testing.md
@@ -227,6 +227,12 @@ Guidelines:
 
 The goal is: every await in the test is bounded, and the suite timeout is generous enough that it only fires if something truly unexpected happens. When a test fails, the error should say *what* timed out, not just "suite timeout exceeded."
 
+**All timeouts are wall-clock time.** Every `WITH timeout`, `poll_until` and `WAIT` in an
+integration spec measures real elapsed time — the test is waiting on a real server over a real
+network. Derived tests in frameworks that virtualise time by default must run these waits
+against the real clock; see the *Integration timeouts are wall-clock* section in
+`writing-derived-tests.md` for the failure mode and recommended helpers.
+
 ### Avoiding Flaky Tests
 
 - Use polling with timeouts instead of fixed waits (see `README.md` polling conventions)

--- a/uts/docs/integration-testing.md
+++ b/uts/docs/integration-testing.md
@@ -99,8 +99,6 @@ realtime/
     presence/
       presence_lifecycle_test.md
       ...
-    helpers/
-      proxy.md                             # Proxy infrastructure spec
     proxy/                                 # Proxy-based tests (sandbox + proxy)
       connection_open_failures.md
       connection_resume.md
@@ -151,7 +149,7 @@ AFTER ALL TESTS:
 
 ### Proxy Setup (integration-proxy only)
 
-Proxy tests additionally set up a proxy session per test or group of tests. See `realtime/integration/helpers/proxy.md` for the proxy infrastructure API.
+Proxy tests additionally set up a proxy session per test or group of tests. See `docs/proxy.md` for the proxy infrastructure API.
 
 ```pseudo
 BEFORE EACH TEST:

--- a/uts/docs/proxy.md
+++ b/uts/docs/proxy.md
@@ -242,5 +242,5 @@ ClientOptions(
 8. Each test file provisions a sandbox app in `BEFORE ALL TESTS` and cleans up in `AFTER ALL TESTS`
 9. Each test creates its own proxy session and cleans it up after
 10. All `WITH timeout` / `poll_until` / `WAIT` durations are **wall-clock (real) time** — see
-    the *Integration timeouts are wall-clock* section in `docs/writing-derived-tests.md` for
+    the *Integration timeouts are wall-clock* section in `writing-derived-tests.md` for
     the virtual-time trap in derived tests

--- a/uts/docs/writing-derived-tests.md
+++ b/uts/docs/writing-derived-tests.md
@@ -268,6 +268,27 @@ const timer = setTimeout(() => reject(new Error('Timed out')), 5000);
 connection.once('connected', () => { clearTimeout(timer); resolve(); });
 ```
 
+### Integration timeouts are wall-clock (beware virtual-time frameworks)
+
+The rule above is inverted for **integration and proxy tests**: every `WITH timeout`,
+`poll_until` and `WAIT` in an integration spec is **wall-clock (real) time**, because the test
+is waiting on a real server or proxy over a real network.
+
+This is a trap in test frameworks that virtualise time by default. For example,
+kotlinx-coroutines' `runTest` runs the test body on a virtual clock: a bare `withTimeout(15s)`
+wrapping a real network await measures *virtual* time, which fast-forwards the moment the test
+coroutine idles — the timeout fires almost instantly, long before the server can respond, with
+a misleading "Timed out after 15s" error. The same applies to a bare `delay()`, which skips
+instead of waiting.
+
+Derived integration tests in such frameworks must run their waits against the real clock —
+e.g. dispatch onto a real-thread dispatcher before applying the timeout
+(`withContext(Dispatchers.Default.limitedParallelism(1)) { withTimeout(...) { ... } }` in
+Kotlin), or use the framework's escape hatch for real time. Define shared helpers
+(`awaitState`, `pollUntil`, `withRealTimeout`, ...) that encapsulate this once, and use them for
+every wait in integration test bodies. Unit tests are unaffected — there, fake/virtual timers
+remain the preferred mechanism.
+
 ### Cleanup with afterEach
 
 Always restore mocks in `afterEach`, not just at the end of each test. If a test throws before its cleanup code, the next test inherits dirty state. Use the SDK's mock restoration mechanism (e.g. `restoreAll()`) in an `afterEach` hook.

--- a/uts/docs/writing-test-specs.md
+++ b/uts/docs/writing-test-specs.md
@@ -21,7 +21,7 @@ This guide provides comprehensive guidance for writing portable test specificati
 - Run against Ably Sandbox through a programmable proxy ([ably/uts-proxy](https://github.com/ably/uts-proxy))
 - Proxy transparently forwards traffic but can inject faults via rules
 - Use for testing fault behaviour: connection failures, token renewal under errors, heartbeat starvation, channel error injection
-- See `realtime/integration/helpers/proxy.md` for the full proxy infrastructure spec
+- See `docs/proxy.md` for the full proxy infrastructure spec
 
 ## Test IDs
 
@@ -296,7 +296,7 @@ mock_ws.active_connection.simulate_disconnect()
 
 ## Proxy Integration Tests
 
-For detailed proxy infrastructure documentation, see `realtime/integration/helpers/proxy.md`.
+For detailed proxy infrastructure documentation, see `docs/proxy.md`.
 
 ### When to Use Proxy Tests
 
@@ -317,7 +317,7 @@ Spec points: `RTN14a`, `RTN14b`, ...
 Proxy integration test against Ably Sandbox endpoint
 
 ## Proxy Infrastructure
-See `realtime/integration/helpers/proxy.md` for proxy infrastructure specification.
+See `docs/proxy.md` for proxy infrastructure specification.
 
 ## Corresponding Unit Tests
 - `realtime/unit/connection/connection_failures_test.md` — RTN15a, RTN15b
@@ -1029,8 +1029,6 @@ realtime/
       connection_open_failures_test.md
       ...
   integration/
-    helpers/
-      proxy.md                # Proxy infrastructure spec
     proxy/
       connection_open_failures.md   # RTN14 tests via proxy
       connection_resume.md          # RTN15 tests via proxy

--- a/uts/docs/writing-test-specs.md
+++ b/uts/docs/writing-test-specs.md
@@ -587,6 +587,10 @@ This means implementations should:
 - Otherwise wait for state change events with timeout
 - Fail if timeout expires
 
+In **integration and proxy** specs these timeouts are **wall-clock time** (the test waits on a
+real server — see the *Timeout Strategy* section in `docs/integration-testing.md`); in unit specs they may be
+realised with fake/virtual timers.
+
 ## Timer Mocking
 
 Tests verifying timeout behavior should use timer mocking where practical to avoid slow tests.

--- a/uts/docs/writing-test-specs.md
+++ b/uts/docs/writing-test-specs.md
@@ -21,7 +21,7 @@ This guide provides comprehensive guidance for writing portable test specificati
 - Run against Ably Sandbox through a programmable proxy ([ably/uts-proxy](https://github.com/ably/uts-proxy))
 - Proxy transparently forwards traffic but can inject faults via rules
 - Use for testing fault behaviour: connection failures, token renewal under errors, heartbeat starvation, channel error injection
-- See `docs/proxy.md` for the full proxy infrastructure spec
+- See `uts/docs/proxy.md` for the full proxy infrastructure spec
 
 ## Test IDs
 
@@ -296,7 +296,7 @@ mock_ws.active_connection.simulate_disconnect()
 
 ## Proxy Integration Tests
 
-For detailed proxy infrastructure documentation, see `docs/proxy.md`.
+For detailed proxy infrastructure documentation, see `uts/docs/proxy.md`.
 
 ### When to Use Proxy Tests
 
@@ -317,7 +317,7 @@ Spec points: `RTN14a`, `RTN14b`, ...
 Proxy integration test against Ably Sandbox endpoint
 
 ## Proxy Infrastructure
-See `docs/proxy.md` for proxy infrastructure specification.
+See `uts/docs/proxy.md` for proxy infrastructure specification.
 
 ## Corresponding Unit Tests
 - `realtime/unit/connection/connection_failures_test.md` — RTN15a, RTN15b

--- a/uts/objects/PLAN.md
+++ b/uts/objects/PLAN.md
@@ -56,7 +56,7 @@ All new test files go in `specification/uts/objects/`.
 | `integration/objects_lifecycle_test.md` | RTO23, RTPO15, RTPO17 (create objects, mutate via PathObject, read back, REST provisioning) | ~6 |
 | `integration/objects_sync_test.md` | RTO4, RTO5, RTO17 (attach, sync sequence, re-attach) | ~4 |
 | ~~`integration/objects_batch_test.md`~~ | ~~Batch API not in current spec revision~~ | — |
-| `integration/objects_gc_test.md` | RTO10, RTLM19 (behavioral GC verification with ADVANCE_TIME) | ~2 |
+| `integration/objects_gc_test.md` | RTO10, RTLM19 (observable tombstone semantics: undefined/null reads, re-create with new objectId; the timer-based GC sweep is unit-tier) | ~2 |
 
 ### Proxy Integration Tests
 | File | Spec Points | ~Tests |
@@ -380,6 +380,6 @@ onMessageFromClient: (msg) => {
 | Batch API deferred | Not included in current spec revision (a397e34); may be added in a future spec update |
 | LiveObject/LiveMap/LiveCounter marked internal but still unit-tested | Direct testing of CRDT logic is essential; public API tests can't cover all edge cases |
 | Test IDs use `objects/unit/` prefix | Matches directory structure, not nested under `realtime/` |
-| Behavioral GC testing via ADVANCE_TIME | Verify GC through observable consequences (value becomes null, object recreatable) rather than internal pool state inspection |
+| Behavioral GC testing tiered by clock control | Unit tier verifies the timer-based sweep with fake timers + ADVANCE_TIME; the integration tier verifies observable consequences only (value becomes undefined/null, object recreatable) since integration tests run on wall-clock time |
 | Table-driven tests for input validation | Use FOR loops over scenario arrays (like ably-js forScenarios) to test all invalid/valid type combinations |
 | Bytes data type coverage | Standard test pool includes "avatar" bytes entry; compact/compactJson/value tests verify base64 encoding |

--- a/uts/objects/PLAN.md
+++ b/uts/objects/PLAN.md
@@ -61,7 +61,7 @@ All new test files go in `specification/uts/objects/`.
 ### Proxy Integration Tests
 | File | Spec Points | ~Tests |
 |------|-------------|--------|
-| `integration/proxy/objects_faults.md` | RTO5a2, RTO7, RTO8, RTO17, RTO20e (sync interruption, mutation buffering during re-sync, server-initiated detach, publish failure on FAILED channel, publish during delayed sync) | ~5 |
+| `integration/proxy/objects_faults.md` | RTO5a2, RTO7, RTO8, RTO17, RTO20e (sync interruption, mutation buffering during re-sync, server-initiated detach, in-flight publish failing when channel enters FAILED during sync wait, publish during delayed sync) | ~5 |
 
 **Totals: ~20 files, ~310 tests**
 

--- a/uts/objects/integration/objects_gc_test.md
+++ b/uts/objects/integration/objects_gc_test.md
@@ -1,0 +1,166 @@
+# Objects GC Integration Tests
+
+Spec points: `RTO10`, `RTLM19`, `RTLM5d2h`, `RTLM7`
+
+## Test Type
+Integration test against Ably sandbox
+
+## Protocol Variants
+json, msgpack
+
+Each test in this file runs once per protocol variant. The `PROTOCOL` variable
+is set to `"json"` or `"msgpack"` for the current run. Client options should set
+`useBinaryProtocol: PROTOCOL == "msgpack"`.
+
+## Purpose
+
+Behavioral verification of tombstone semantics end-to-end against the real
+server: removing a map entry tombstones it (RTLM7), tombstoned entries read
+back as undefined/null (RTLM5d2h), and the same key is recreatable — the
+server assigns a fresh objectId to the replacement object, which is safe
+because tombstoned state is retained for the GC grace period (RTO10).
+
+## Scope
+
+The timer-based GC sweep itself (RTO10a–RTO10c, RTLM19a) is verified at the
+**unit tier** (`objects/unit/realtime_object.md`, RTO10 tests), where the
+clock and the sweep interval are controllable. It is intentionally **not**
+exercised here: integration tests run on wall-clock time against a real
+server (see *Integration timeouts are wall-clock* in
+`docs/writing-derived-tests.md`), and the sweep cadence (RTO10a, ~5 minutes)
+combined with the server-provided grace period (RTO10b, default 24 hours per
+RTO10b3) is not observable within test timeouts. Do not use `ADVANCE_TIME`
+in this file.
+
+> Note: assertions of the form `value() == null` denote the spec's
+> undefined/null absent value (RTLM5d2h); a deriving SDK asserts its
+> language's mapping (e.g. `undefined` in JavaScript).
+
+## Sandbox Setup
+
+Tests run against the Ably Sandbox at `https://sandbox.realtime.ably-nonprod.net`.
+
+### App Provisioning
+
+```pseudo
+BEFORE ALL TESTS:
+  response = POST https://sandbox.realtime.ably-nonprod.net/apps
+    WITH body from ably-common/test-resources/test-app-setup.json
+
+  app_config = parse_json(response.body)
+  api_key = app_config.keys[0].key_str
+  app_id = app_config.app_id
+
+AFTER ALL TESTS:
+  DELETE https://sandbox.realtime.ably-nonprod.net/apps/{app_id}
+    WITH Authorization: Basic {api_key}
+```
+
+### Notes
+- Each test uses a unique channel name
+
+---
+
+## RTO10 - Tombstoned object is recreatable with new objectId
+
+**Test ID**: `objects/integration/RTO10/tombstoned-object-gc-recreate-0`
+
+**Spec requirement:** After an object is tombstoned (removed from its parent
+map), a new object can be created at the same map key. The new object gets a
+different server-assigned objectId, confirming the old object is gone while
+its tombstone is retained for the grace period (RTO10).
+
+### Setup
+```pseudo
+channel_name = "objects-gc-object-" + random_id()
+
+client = Realtime(options: { key: api_key, endpoint: "nonprod:sandbox", autoConnect: false, useBinaryProtocol: PROTOCOL == "msgpack" })
+client.connect()
+AWAIT_STATE client.connection.state == CONNECTED
+  WITH timeout: 15 seconds
+
+channel = client.channels.get(channel_name, { modes: ["OBJECT_SUBSCRIBE", "OBJECT_PUBLISH"] })
+root = AWAIT channel.object.get()
+  WITH timeout: 15 seconds
+```
+
+### Test Steps
+```pseudo
+// Create a counter
+AWAIT root.set("counter", LiveCounter.create(42))
+poll_until(root.get("counter").value() == 42, timeout: 10s)
+
+counter_id = root.get("counter").instance().id
+
+// Remove it (tombstones the entry and the object, RTLM7)
+AWAIT root.remove("counter")
+
+// RTLM5d2h: tombstoned entries read back as undefined/null
+poll_until(root.get("counter").value() == null, timeout: 10s)
+
+// Create a new counter at the same key
+AWAIT root.set("counter", LiveCounter.create(99))
+poll_until(root.get("counter").value() == 99, timeout: 10s)
+```
+
+### Assertions
+```pseudo
+ASSERT root.get("counter").value() == 99
+ASSERT root.get("counter").instance().id != counter_id
+```
+
+### Teardown
+```pseudo
+client.close()
+```
+
+---
+
+## RTLM19 - Tombstoned map entry is re-settable
+
+**Test ID**: `objects/integration/RTLM19/tombstoned-entry-gc-reset-0`
+
+**Spec requirement:** After a map entry is tombstoned (removed, RTLM7), the
+entry can be re-set. The subsequent MAP_SET succeeds because the server
+assigns a newer serial than the removal's, while the tombstoned entry is
+retained for the grace period pending GC (RTLM19).
+
+### Setup
+```pseudo
+channel_name = "objects-gc-entry-" + random_id()
+
+client = Realtime(options: { key: api_key, endpoint: "nonprod:sandbox", autoConnect: false, useBinaryProtocol: PROTOCOL == "msgpack" })
+client.connect()
+AWAIT_STATE client.connection.state == CONNECTED
+  WITH timeout: 15 seconds
+
+channel = client.channels.get(channel_name, { modes: ["OBJECT_SUBSCRIBE", "OBJECT_PUBLISH"] })
+root = AWAIT channel.object.get()
+  WITH timeout: 15 seconds
+```
+
+### Test Steps
+```pseudo
+// Set then remove a key
+AWAIT root.set("ephemeral", "temporary")
+poll_until(root.get("ephemeral").value() == "temporary", timeout: 10s)
+
+AWAIT root.remove("ephemeral")
+
+// RTLM5d2h: tombstoned entries read back as undefined/null
+poll_until(root.get("ephemeral").value() == null, timeout: 10s)
+
+// Set the same key again
+AWAIT root.set("ephemeral", "revived")
+poll_until(root.get("ephemeral").value() == "revived", timeout: 10s)
+```
+
+### Assertions
+```pseudo
+ASSERT root.get("ephemeral").value() == "revived"
+```
+
+### Teardown
+```pseudo
+client.close()
+```

--- a/uts/objects/integration/objects_sync_test.md
+++ b/uts/objects/integration/objects_sync_test.md
@@ -172,7 +172,7 @@ client.close()
 
 ---
 
-## RTO4 - Attach without OBJECT_SUBSCRIBE still resolves get() with empty pool
+## RTO4 - Attach without OBJECT_PUBLISH still resolves get() with empty pool
 
 **Test ID**: `objects/integration/RTO4/attach-subscribe-only-0`
 

--- a/uts/objects/integration/proxy/objects_faults.md
+++ b/uts/objects/integration/proxy/objects_faults.md
@@ -8,7 +8,7 @@ Proxy integration test against Ably Sandbox endpoint
 
 ## Proxy Infrastructure
 
-See `realtime/integration/helpers/proxy.md` for the full proxy infrastructure specification.
+See `docs/proxy.md` for the full proxy infrastructure specification.
 
 ## Corresponding Unit Tests
 
@@ -62,7 +62,7 @@ AFTER EACH TEST:
 | OBJECT_SYNC | 20 |
 
 > Rule `match.action` values are **strings**; objects actions must use numeric strings
-> (e.g. `"20"`) — see the *Match Conditions* section in `realtime/integration/helpers/proxy.md`.
+> (e.g. `"20"`) — see the *Match Conditions* section in `docs/proxy.md`.
 
 ---
 

--- a/uts/objects/integration/proxy/objects_faults.md
+++ b/uts/objects/integration/proxy/objects_faults.md
@@ -1,6 +1,6 @@
 # Objects Proxy Integration Tests
 
-Spec points: `RTO5a2`, `RTO7`, `RTO8`, `RTO17`, `RTO20e`
+Spec points: `RTO5a2`, `RTO7`, `RTO8`, `RTO17`, `RTO20e`, `RTO20e1`
 
 ## Test Type
 
@@ -13,7 +13,9 @@ See `realtime/integration/helpers/proxy.md` for the full proxy infrastructure sp
 ## Corresponding Unit Tests
 
 - `objects/unit/objects_pool.md` — RTO5a2 (new sync discards old), RTO7/RTO8 (buffering during SYNCING)
-- `objects/unit/realtime_object.md` — RTO17 (sync state events), RTO20e (publishAndApply waits for SYNCED/fails on FAILED)
+- `objects/unit/realtime_object.md` — RTO17 (sync state events), RTO20e (publishAndApply waits
+  for SYNCED), RTO20e1 (in-flight operation fails with 92008 when the channel leaves the
+  attached state during the sync wait)
 
 ## Sandbox Setup
 
@@ -39,10 +41,11 @@ AFTER ALL TESTS:
 
 ```pseudo
 AFTER EACH TEST:
-  IF client IS NOT null AND client.connection.state IN [connected, connecting, disconnected]:
-    client.connection.close()
-    AWAIT_STATE client.connection.state == ConnectionState.closed
-      WITH timeout: 10 seconds
+  FOR EACH client created by the test (client / client_a / client_b):
+    IF client.connection.state IN [connected, connecting, disconnected]:
+      client.connection.close()
+      AWAIT_STATE client.connection.state == ConnectionState.closed
+        WITH timeout: 10 seconds
   IF session IS NOT null:
     session.close()
 ```
@@ -51,10 +54,15 @@ AFTER EACH TEST:
 
 | Name | Number |
 |------|--------|
+| ACK | 1 |
+| ERROR | 9 |
 | ATTACHED | 11 |
 | DETACHED | 13 |
 | OBJECT | 19 |
 | OBJECT_SYNC | 20 |
+
+> Rule `match.action` values are **strings**; objects actions must use numeric strings
+> (e.g. `"20"`) — see the *Match Conditions* section in `realtime/integration/helpers/proxy.md`.
 
 ---
 
@@ -82,7 +90,7 @@ session = create_proxy_session(
   endpoint: "nonprod:sandbox",
 
   rules: [{
-    "match": { "type": "ws_frame_to_client", "action": 20 },
+    "match": { "type": "ws_frame_to_client", "action": "20" },
     "action": { "type": "disconnect" },
     "times": 1,
     "comment": "RTO5a2: Disconnect after first OBJECT_SYNC to interrupt sync"
@@ -156,6 +164,7 @@ AWAIT_STATE client_a.connection.state == CONNECTED
 
 channel_a = client_a.channels.get(channel_name, { modes: ["OBJECT_SUBSCRIBE", "OBJECT_PUBLISH"] })
 root_a = AWAIT channel_a.object.get()
+  WITH timeout: 15 seconds
 
 // Set initial data
 AWAIT root_a.set("key1", "initial")
@@ -305,11 +314,19 @@ ASSERT root.get("before_detach").value() == "hello"
 
 | Spec | Requirement |
 |------|-------------|
-| RTO20e | publishAndApply waits for SYNCED; fails with 92008 if channel enters DETACHED/SUSPENDED/FAILED |
+| RTO20e | publishAndApply waits for the sync state to transition to SYNCED before applying locally |
+| RTO20e1 | If the channel enters DETACHED/SUSPENDED/FAILED while waiting, the operation fails with 92008, statusCode 400, cause = channel errorReason |
 
-Client sets up a channel with objects, then the proxy injects a channel ERROR
-to transition to FAILED. A PathObject mutation (which uses publishAndApply
-internally) should fail with error 92008.
+The client syncs a channel, is forced back into SYNCING, and issues a mutation
+*while* SYNCING — the publish and its ACK complete against the real server, then
+publishAndApply parks in the RTO20e wait for SYNCED. The proxy then injects a
+channel ERROR so the channel enters FAILED whilst the operation is waiting; the
+pending mutation must fail with error 92008 (RTO20e1).
+
+> Note: the mutation must be in flight *before* the channel fails. A mutation issued on a
+> channel already in DETACHED/FAILED/SUSPENDED fails the RTO26b write precondition with 90001
+> and never reaches publishAndApply — that is different behaviour, not this test. The unit-tier
+> test `objects/unit/RTO20e1/fails-on-channel-failed-0` uses the same sequence.
 
 ### Setup
 
@@ -344,7 +361,31 @@ AWAIT_STATE client.connection.state == CONNECTED
 root = AWAIT channel.object.get()
   WITH timeout: 15 seconds
 
-// Inject channel ERROR to transition to FAILED
+// Force the objects back into SYNCING: inject an ATTACHED (action 11) carrying the
+// HAS_OBJECTS flag (bit 7, i.e. flags: 128). RTO4c starts a new sync sequence on every
+// ATTACHED protocol message; the server never sent this ATTACHED, so no OBJECT_SYNC
+// follows and the objects remain SYNCING. The channel itself stays ATTACHED.
+session.trigger_action({
+  type: "inject_to_client",
+  message: { action: 11, channel: channel_name, flags: 128 }
+})
+
+// Mutate WHILE SYNCING: the channel is ATTACHED so the write preconditions (RTO26)
+// pass and the publish + ACK complete against the real server; publishAndApply then
+// waits for a SYNCED that will never arrive (RTO20e). Do not await yet.
+pending = root.set("key", "value")
+
+// Ensure the operation is in the RTO20e sync-wait, not still publishing: wait until
+// the proxy log shows the server's ACK (action 1) for the OBJECT publish, then allow
+// a brief real-time yield for the client to move the ACKed operation into the wait.
+// (There is no observable client state between "ACK processed" and "parked in the
+// sync-wait" to poll on, so a small fixed yield is required — the deriving SDK may
+// substitute an equivalent scheduler yield.)
+poll_until(session.get_log() CONTAINS event WHERE type == "ws_frame"
+  AND direction == "server_to_client" AND message.action == 1, timeout: 10s)
+WAIT 500ms  // real (wall-clock) time
+
+// The channel enters FAILED whilst the operation waits for SYNCED (RTO20e1)
 session.trigger_action({
   type: "inject_to_client",
   message: {
@@ -357,14 +398,16 @@ session.trigger_action({
 AWAIT_STATE channel.state == ChannelState.failed
   WITH timeout: 15 seconds
 
-// Attempt a mutation — should fail since channel is FAILED
-AWAIT root.set("key", "value") FAILS WITH error
+AWAIT pending FAILS WITH error
+  WITH timeout: 15 seconds
 ```
 
 ### Assertions
 
 ```pseudo
 ASSERT error.code == 92008
+ASSERT error.statusCode == 400
+// RTO20e1: cause is set to RealtimeChannel.errorReason — the injected channel ERROR
 ASSERT error.cause IS NOT null
 ASSERT error.cause.code == 90000
 ```
@@ -398,6 +441,7 @@ AWAIT_STATE client_a.connection.state == CONNECTED
 
 channel_a = client_a.channels.get(channel_name, { modes: ["OBJECT_SUBSCRIBE", "OBJECT_PUBLISH"] })
 root_a = AWAIT channel_a.object.get()
+  WITH timeout: 15 seconds
 
 // Set up initial data
 AWAIT root_a.set("existing", "before")
@@ -407,7 +451,7 @@ session = create_proxy_session(
   endpoint: "nonprod:sandbox",
 
   rules: [{
-    "match": { "type": "ws_frame_to_client", "action": 20 },
+    "match": { "type": "ws_frame_to_client", "action": "20" },
     "action": { "type": "delay", "delayMs": 3000 },
     "times": 1,
     "comment": "Delay first OBJECT_SYNC to keep B in SYNCING state"

--- a/uts/objects/integration/proxy/objects_faults.md
+++ b/uts/objects/integration/proxy/objects_faults.md
@@ -8,7 +8,7 @@ Proxy integration test against Ably Sandbox endpoint
 
 ## Proxy Infrastructure
 
-See `docs/proxy.md` for the full proxy infrastructure specification.
+See `uts/docs/proxy.md` for the full proxy infrastructure specification.
 
 ## Corresponding Unit Tests
 
@@ -62,7 +62,7 @@ AFTER EACH TEST:
 | OBJECT_SYNC | 20 |
 
 > Rule `match.action` values are **strings**; objects actions must use numeric strings
-> (e.g. `"20"`) — see the *Match Conditions* section in `docs/proxy.md`.
+> (e.g. `"20"`) — see the *Match Conditions* section in `uts/docs/proxy.md`.
 
 ---
 

--- a/uts/realtime/integration/helpers/proxy.md
+++ b/uts/realtime/integration/helpers/proxy.md
@@ -112,6 +112,14 @@ Rules are evaluated in order. First matching rule wins. Unmatched traffic passes
 
 **`count`**: 1-based occurrence counter. `count: 2` matches only the 2nd occurrence.
 
+**`action`** (frame matches): must be a **string** — either a protocol action *name*
+(e.g. `"ATTACHED"`) or a *numeric string* (e.g. `"20"`). A JSON number is rejected at
+session creation with HTTP 400 (`cannot unmarshal number into Go struct field
+MatchConfig.match.action of type string`). Note: uts-proxy v0.3.0 resolves action
+*names* only up to `AUTH` (17) — an unresolvable name (e.g. `"OBJECT_SYNC"`) makes the
+rule silently never match, so use numeric strings for `OBJECT` (`"19"`),
+`OBJECT_SYNC` (`"20"`) and `ANNOTATION` (`"21"`) until the proxy's name table is extended.
+
 ### Actions
 
 ```json
@@ -233,3 +241,6 @@ ClientOptions(
 7. Timeouts are generous (10-30s) since real network is involved
 8. Each test file provisions a sandbox app in `BEFORE ALL TESTS` and cleans up in `AFTER ALL TESTS`
 9. Each test creates its own proxy session and cleans it up after
+10. All `WITH timeout` / `poll_until` / `WAIT` durations are **wall-clock (real) time** — see
+    the *Integration timeouts are wall-clock* section in `docs/writing-derived-tests.md` for
+    the virtual-time trap in derived tests

--- a/uts/realtime/integration/proxy/auth_reauth.md
+++ b/uts/realtime/integration/proxy/auth_reauth.md
@@ -6,7 +6,7 @@ Spec points: `RTN22`, `RTC8a`
 
 Proxy integration test against Ably Sandbox endpoint.
 
-Uses the programmable proxy (`uts/test/proxy/`) to inject transport-level faults while the SDK communicates with the real Ably backend. See `uts/test/realtime/integration/helpers/proxy.md` for proxy infrastructure details.
+Uses the programmable proxy ([ably/uts-proxy](https://github.com/ably/uts-proxy)) to inject transport-level faults while the SDK communicates with the real Ably backend. See `uts/docs/proxy.md` for proxy infrastructure details.
 
 Corresponding unit tests:
 - `uts/test/realtime/unit/connection/server_initiated_reauth_test.md` (RTN22, RTN22a)

--- a/uts/realtime/integration/proxy/channel_faults.md
+++ b/uts/realtime/integration/proxy/channel_faults.md
@@ -8,7 +8,7 @@ Proxy integration test against Ably Sandbox endpoint
 
 ## Proxy Infrastructure
 
-See `uts/test/realtime/integration/helpers/proxy.md` for the full proxy infrastructure specification.
+See `uts/docs/proxy.md` for the full proxy infrastructure specification.
 
 ## Corresponding Unit Tests
 

--- a/uts/realtime/integration/proxy/connection_open_failures.md
+++ b/uts/realtime/integration/proxy/connection_open_failures.md
@@ -8,7 +8,7 @@ Proxy integration test against Ably Sandbox endpoint
 
 ## Proxy Infrastructure
 
-See `uts/test/realtime/integration/helpers/proxy.md` for the full proxy infrastructure specification.
+See `uts/docs/proxy.md` for the full proxy infrastructure specification.
 
 ## Related Unit Tests
 

--- a/uts/realtime/integration/proxy/connection_resume.md
+++ b/uts/realtime/integration/proxy/connection_resume.md
@@ -6,7 +6,7 @@ Spec points: `RTN15a`, `RTN15b`, `RTN15c6`, `RTN15c7`, `RTN15g`, `RTN15g2`, `RTN
 
 Proxy integration test against Ably Sandbox endpoint.
 
-Uses the programmable proxy (`uts/test/proxy/`) to inject transport-level faults while the SDK communicates with the real Ably backend. See `uts/test/realtime/integration/helpers/proxy.md` for proxy infrastructure details.
+Uses the programmable proxy ([ably/uts-proxy](https://github.com/ably/uts-proxy)) to inject transport-level faults while the SDK communicates with the real Ably backend. See `uts/docs/proxy.md` for proxy infrastructure details.
 
 Corresponding unit tests: `uts/test/realtime/unit/connection/connection_failures_test.md`, `uts/test/realtime/unit/connection/connection_recovery_test.md`
 

--- a/uts/realtime/integration/proxy/connection_resume.md
+++ b/uts/realtime/integration/proxy/connection_resume.md
@@ -815,7 +815,7 @@ session = create_proxy_session(
     },
     {
       "match": { "type": "ws_connect", "count": 2 },
-      "action": { "type": "refuse" },
+      "action": { "type": "refuse_connection" },
       "times": 1,
       "comment": "RTN15g: Refuse 2nd ws_connect — keeps client disconnected until TTL expires and SUSPENDED fires"
     }

--- a/uts/realtime/integration/proxy/heartbeat.md
+++ b/uts/realtime/integration/proxy/heartbeat.md
@@ -8,7 +8,7 @@ Proxy integration test against Ably Sandbox endpoint
 
 ## Proxy Infrastructure
 
-See `uts/test/realtime/integration/helpers/proxy.md` for the full proxy infrastructure specification.
+See `uts/docs/proxy.md` for the full proxy infrastructure specification.
 
 ## Related Unit Tests
 

--- a/uts/realtime/integration/proxy/presence_reentry.md
+++ b/uts/realtime/integration/proxy/presence_reentry.md
@@ -8,7 +8,7 @@ Proxy integration test against Ably Sandbox endpoint
 
 ## Proxy Infrastructure
 
-See `uts/test/realtime/integration/helpers/proxy.md` for the full proxy infrastructure specification.
+See `uts/docs/proxy.md` for the full proxy infrastructure specification.
 
 ## Corresponding Unit Tests
 

--- a/uts/realtime/integration/proxy/rest_faults.md
+++ b/uts/realtime/integration/proxy/rest_faults.md
@@ -8,7 +8,7 @@ Proxy integration test against Ably Sandbox endpoint
 
 ## Proxy Infrastructure
 
-See `uts/test/realtime/integration/helpers/proxy.md` for the full proxy infrastructure specification.
+See `uts/docs/proxy.md` for the full proxy infrastructure specification.
 
 ## Corresponding Unit Tests
 

--- a/uts/rest/integration/proxy/rest_fallback.md
+++ b/uts/rest/integration/proxy/rest_fallback.md
@@ -8,7 +8,7 @@ Proxy integration test against Ably Sandbox endpoint
 
 ## Proxy Infrastructure
 
-See `uts/realtime/integration/helpers/proxy.md` for the full proxy infrastructure specification.
+See `uts/docs/proxy.md` for the full proxy infrastructure specification.
 
 ## Corresponding Unit Tests
 


### PR DESCRIPTION
- Fixed https://ably.atlassian.net/browse/AIT-1106

## Intent

While evaluating the derived ably-java test suite (`ObjectsFaultsTest`) against the real sandbox through `uts-proxy`, every test in `objects/integration/proxy/objects_faults.md` failed. Root-causing those failures surfaced one genuine spec error (RTO20e), several spec/tooling format mismatches that fail silently or with opaque errors, and a recurring translation trap around timeouts. This PR fixes the specs at source and adds the guidance so other deriving SDKs don't rediscover these the hard way.

Every behavioural claim below was cross-validated against the features spec (`objects-features.md`), ably-js source (the reference SDK), and a passing ably-java derived test run against the sandbox.

## Changes

### 1. `objects/integration/proxy/objects_faults.md` — RTO20e spec error (the substantive fix)

The test `objects/proxy/RTO20e/publish-fails-on-channel-failed-0` mutated **after** the channel was already FAILED, yet asserted error **92008**:

- **RTO26b** requires a mutation on an already-DETACHED/FAILED/SUSPENDED channel to fail with **90001** "before doing anything else" — it never reaches `publishAndApply`.
- **RTO20e1**'s 92008 applies only to an operation **already waiting** for SYNCED when the channel transitions.
- ably-js confirms: `throwIfInvalidWriteApiConfiguration` → `invalidStateError()` = 90001/400; the only 92008 is the sync-wait rejection in `publishAndApply()`. Its own test ("publishAndApply rejects when channel state changes during sync wait") never mutates after FAILED. ably-java behaves identically.
- The test's own title ("enters FAILED **during SYNCING**") and the sibling unit test (`objects/unit/RTO20e1`) already describe the correct sequence — the proxy steps were the outlier.

The steps are restructured to the RTO20e1 sequence: force SYNCING via an injected ATTACHED carrying HAS_OBJECTS (`flags: 128`, RTO4c), mutate while SYNCING, wait for the publish ACK in the proxy log plus a brief real-time yield, inject the channel ERROR, and assert the pending operation fails with 92008 / statusCode 400 / cause 90000. A note explains the RTO26b-vs-RTO20e1 distinction so the inversion doesn't creep back in. The requirement table is split into RTO20e (wait) and RTO20e1 (fail) rows, mirroring the unit spec.

### 2. Proxy rule format fixes (silent/opaque failure modes)

- `objects_faults.md`: two rules wrote `"match": { "action": 20 }` as a JSON **number** — uts-proxy rejects this at session creation with HTTP 400 (`cannot unmarshal number into Go struct field MatchConfig.match.action of type string`). Now `"20"` (string).
- `connection_resume.md` (RTN15g): rule action type `"refuse"` does not exist (`refuse_connection` does). Unknown action types hit a silent passthrough in the proxy, so the second `ws_connect` was never refused and the test premise broke with no error. Corrected.
- `helpers/proxy.md`: the Match Conditions section now documents the `action` string format explicitly, plus the v0.3.0 limitation that action *names* resolve only up to `AUTH` (17) — unresolvable names (e.g. `"OBJECT_SYNC"`) silently never match, so objects actions need numeric strings until the proxy's name table is extended.
- A full regex sweep of `uts/objects`, `uts/realtime` and `uts/rest` (all match types, action types, `trigger_action` types and match fields validated against the Go proxy's structs) found no further instances.

### 3. Wall-clock timeout guidance (recurring translation trap)

All `WITH timeout` / `poll_until` / `WAIT` durations in integration specs are wall-clock time, but frameworks that virtualise time by default (e.g. kotlinx-coroutines `runTest`) fast-forward the clock while the test idles — a naively translated 15s timeout around a real network await fires instantly with a misleading error. Added:

- `docs/writing-derived-tests.md`: new section *Integration timeouts are wall-clock (beware virtual-time frameworks)* — the counterpart to the existing *No real timers in unit tests* note — with the failure mode and the shared-helper remedy.
- `docs/integration-testing.md` (Timeout Strategy) and `docs/writing-test-specs.md` (State Transitions): short pointers to it.
- `helpers/proxy.md`: new convention (#10).
- `objects_faults.md`: the two previously unbounded `object.get()` awaits now carry `WITH timeout: 15 seconds` — every await in the file is bounded, and the Common Cleanup covers multi-client tests explicitly.

### 4. `objects/PLAN.md`

Summary row updated to the corrected RTO20e scenario ("in-flight publish failing when channel enters FAILED during sync wait").

## Validation

- The corrected `objects_faults.md` is fully implemented by the ably-java derived suite: **all 5 tests pass** against the sandbox through uts-proxy, including the restructured RTO20e (92008 with cause 90000 observed end-to-end).
- A deterministic spec↔test audit reports 5/5 Test ID coverage with no missing assertions.
- Test IDs are unchanged, so existing derived-test `UTS:` tags remain valid.

## Follow-ups (not in this PR)

- `ably/uts-proxy`: extend `actionNames` with `OBJECT`/`OBJECT_SYNC`/`ANNOTATION` so name-based matching works for objects actions.
- Consider moving `realtime/integration/helpers/proxy.md` to `uts/docs/` — it is cross-module infrastructure consumed by realtime, rest and objects; best done as a dedicated rename commit with a reference sweep.
- The RTO20e proxy Test ID (`publish-fails-on-channel-failed-0`) now under-describes the scenario; kept stable for traceability, but a coordinated rename could accompany review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)