### PR TITLE
chore(uts): fix legacy uts/test/ paths in spec cross-references

### DIFF
--- a/uts/realtime/integration/proxy/auth_reauth.md
+++ b/uts/realtime/integration/proxy/auth_reauth.md
@@ -9,9 +9,9 @@ Proxy integration test against Ably Sandbox endpoint.
 Uses the programmable proxy (`uts/test/proxy/`) to inject transport-level faults while the SDK communicates with the real Ably backend. See `uts/test/realtime/integration/helpers/proxy.md` for proxy infrastructure details.
 
 Corresponding unit tests:
-- `uts/test/realtime/unit/connection/server_initiated_reauth_test.md` (RTN22, RTN22a)
-- `uts/test/realtime/unit/auth/realtime_authorize.md` (RTC8a, RTC8a1)
-- `uts/test/realtime/unit/auth/connection_auth_test.md` (RSA4c3 covers RTN22 reauth failure while CONNECTED)
+- `uts/realtime/unit/connection/server_initiated_reauth_test.md` (RTN22, RTN22a)
+- `uts/realtime/unit/auth/realtime_authorize.md` (RTC8a, RTC8a1)
+- `uts/realtime/unit/auth/connection_auth_test.md` (RSA4c3 covers RTN22 reauth failure while CONNECTED)
 
 ## Sandbox Setup
 

--- a/uts/realtime/integration/proxy/channel_faults.md
+++ b/uts/realtime/integration/proxy/channel_faults.md
@@ -12,10 +12,10 @@ See `uts/test/realtime/integration/helpers/proxy.md` for the full proxy infrastr
 
 ## Corresponding Unit Tests
 
-- `uts/test/realtime/unit/channels/channel_attach.md` -- RTL4f (attach timeout)
-- `uts/test/realtime/unit/channels/channel_detach.md` -- RTL5f (detach timeout)
-- `uts/test/realtime/unit/channels/channel_server_initiated_detach.md` -- RTL13a (unsolicited DETACHED triggers reattach)
-- `uts/test/realtime/unit/channels/channel_error.md` -- RTL14 (channel ERROR transitions to FAILED)
+- `uts/realtime/unit/channels/channel_attach.md` -- RTL4f (attach timeout)
+- `uts/realtime/unit/channels/channel_detach.md` -- RTL5f (detach timeout)
+- `uts/realtime/unit/channels/channel_server_initiated_detach.md` -- RTL13a (unsolicited DETACHED triggers reattach)
+- `uts/realtime/unit/channels/channel_error.md` -- RTL14 (channel ERROR transitions to FAILED)
 
 ## Sandbox Setup
 

--- a/uts/realtime/integration/proxy/connection_open_failures.md
+++ b/uts/realtime/integration/proxy/connection_open_failures.md
@@ -12,7 +12,7 @@ See `uts/test/realtime/integration/helpers/proxy.md` for the full proxy infrastr
 
 ## Related Unit Tests
 
-See `uts/test/realtime/unit/connection/connection_open_failures_test.md` for the corresponding unit tests that verify the same spec points with mocked WebSocket.
+See `uts/realtime/unit/connection/connection_open_failures_test.md` for the corresponding unit tests that verify the same spec points with mocked WebSocket.
 
 ## Sandbox Setup
 

--- a/uts/realtime/integration/proxy/connection_resume.md
+++ b/uts/realtime/integration/proxy/connection_resume.md
@@ -8,7 +8,7 @@ Proxy integration test against Ably Sandbox endpoint.
 
 Uses the programmable proxy (`uts/test/proxy/`) to inject transport-level faults while the SDK communicates with the real Ably backend. See `uts/test/realtime/integration/helpers/proxy.md` for proxy infrastructure details.
 
-Corresponding unit tests: `uts/test/realtime/unit/connection/connection_failures_test.md`, `uts/test/realtime/unit/connection/connection_recovery_test.md`
+Corresponding unit tests: `uts/realtime/unit/connection/connection_failures_test.md`, `uts/realtime/unit/connection/connection_recovery_test.md`
 
 ## Sandbox Setup
 

--- a/uts/realtime/integration/proxy/heartbeat.md
+++ b/uts/realtime/integration/proxy/heartbeat.md
@@ -12,7 +12,7 @@ See `uts/test/realtime/integration/helpers/proxy.md` for the full proxy infrastr
 
 ## Related Unit Tests
 
-See `uts/test/realtime/unit/connection/heartbeat_test.md` for the corresponding unit tests that verify the same spec points with mocked WebSocket and fake timers.
+See `uts/realtime/unit/connection/heartbeat_test.md` for the corresponding unit tests that verify the same spec points with mocked WebSocket and fake timers.
 
 ## Sandbox Setup
 

--- a/uts/realtime/integration/proxy/presence_reentry.md
+++ b/uts/realtime/integration/proxy/presence_reentry.md
@@ -12,7 +12,7 @@ See `uts/test/realtime/integration/helpers/proxy.md` for the full proxy infrastr
 
 ## Corresponding Unit Tests
 
-- `uts/test/realtime/unit/presence/realtime_presence_reentry.md` -- RTP17i (automatic re-entry on ATTACHED non-RESUMED), RTP17g (re-entry publishes ENTER with stored clientId and data)
+- `uts/realtime/unit/presence/realtime_presence_reentry.md` -- RTP17i (automatic re-entry on ATTACHED non-RESUMED), RTP17g (re-entry publishes ENTER with stored clientId and data)
 
 ## Sandbox Setup
 

--- a/uts/realtime/integration/proxy/rest_faults.md
+++ b/uts/realtime/integration/proxy/rest_faults.md
@@ -12,9 +12,9 @@ See `uts/test/realtime/integration/helpers/proxy.md` for the full proxy infrastr
 
 ## Corresponding Unit Tests
 
-- `uts/test/rest/unit/auth/token_renewal.md` -- RSC10 (unit test verifies token renewal logic with mocked HTTP)
-- `uts/test/rest/unit/fallback.md` -- RSC15m/REC2c2 (unit test verifies fallback/error handling with mocked HTTP)
-- `uts/test/realtime/unit/channels/channel_publish.md` -- RTL6 (unit test verifies publish request formation)
+- `uts/rest/unit/auth/token_renewal.md` -- RSC10 (unit test verifies token renewal logic with mocked HTTP)
+- `uts/rest/unit/fallback.md` -- RSC15m/REC2c2 (unit test verifies fallback/error handling with mocked HTTP)
+- `uts/realtime/unit/channels/channel_publish.md` -- RTL6 (unit test verifies publish request formation)
 
 ## Sandbox Setup
 

--- a/uts/realtime/unit/auth/connection_auth_test.md
+++ b/uts/realtime/unit/auth/connection_auth_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client and authCallback
 
 ## Mock Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ## Purpose
 

--- a/uts/realtime/unit/auth/realtime_authorize.md
+++ b/uts/realtime/unit/auth/realtime_authorize.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client and authCallback
 
 ## Mock Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ## Purpose
 

--- a/uts/realtime/unit/channels/channel_additional_attached.md
+++ b/uts/realtime/unit/channels/channel_additional_attached.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_annotations.md
+++ b/uts/realtime/unit/channels/channel_annotations.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 
@@ -238,7 +238,7 @@ CLOSE_CLIENT(client)
 
 **Spec requirement:** RTAN1b — Has the same connection and channel state conditions as message publishing, see RTL6c.
 
-Tests that annotation publish fails in FAILED and SUSPENDED channel states, matching the behaviour tested in `uts/test/realtime/unit/channels/channel_publish.md` (RTL6c4). The same connection and channel state preconditions apply.
+Tests that annotation publish fails in FAILED and SUSPENDED channel states, matching the behaviour tested in `uts/realtime/unit/channels/channel_publish.md` (RTL6c4). The same connection and channel state preconditions apply.
 
 ### Setup
 ```pseudo
@@ -460,7 +460,7 @@ CLOSE_CLIENT(client)
 
 **Spec requirement:** RTAN3a — Is identical to `RestAnnotations#get`.
 
-`RealtimeAnnotations#get` uses the same underlying REST endpoint as `RestAnnotations#get`. The tests in `uts/test/rest/unit/channel/annotations.md` (covering RSAN3) should be used to verify that all the same behaviour, parameters, and return types apply when called on a `RealtimeChannel` instance.
+`RealtimeAnnotations#get` uses the same underlying REST endpoint as `RestAnnotations#get`. The tests in `uts/rest/unit/channel/annotations.md` (covering RSAN3) should be used to verify that all the same behaviour, parameters, and return types apply when called on a `RealtimeChannel` instance.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_attach.md
+++ b/uts/realtime/unit/channels/channel_attach.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_attributes.md
+++ b/uts/realtime/unit/channels/channel_attributes.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_connection_state.md
+++ b/uts/realtime/unit/channels/channel_connection_state.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_delta_decoding.md
+++ b/uts/realtime/unit/channels/channel_delta_decoding.md
@@ -7,11 +7,11 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ## Mock VCDiff Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_vcdiff.md` for the full Mock VCDiff Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_vcdiff.md` for the full Mock VCDiff Infrastructure specification.
 
 > **Transport encoding note:** On JSON transport (the default for unit tests),
 > binary vcdiff delta payloads cannot be transmitted as raw bytes — they must be

--- a/uts/realtime/unit/channels/channel_detach.md
+++ b/uts/realtime/unit/channels/channel_detach.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_error.md
+++ b/uts/realtime/unit/channels/channel_error.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_get_message.md
+++ b/uts/realtime/unit/channels/channel_get_message.md
@@ -13,4 +13,4 @@ Unit test with mocked HTTP client
 
 **Spec requirement:** `RealtimeChannel#getMessage` function: same as `RestChannel#getMessage`.
 
-`RealtimeChannel#getMessage` uses the same underlying REST endpoint as `RestChannel#getMessage`. The tests in `uts/test/rest/unit/channel/get_message.md` (covering RSL11) should be used to verify that all the same behaviour, parameters, and return types apply when called on a `RealtimeChannel` instance.
+`RealtimeChannel#getMessage` uses the same underlying REST endpoint as `RestChannel#getMessage`. The tests in `uts/rest/unit/channel/get_message.md` (covering RSL11) should be used to verify that all the same behaviour, parameters, and return types apply when called on a `RealtimeChannel` instance.

--- a/uts/realtime/unit/channels/channel_history.md
+++ b/uts/realtime/unit/channels/channel_history.md
@@ -16,7 +16,7 @@ Unit test with mocked HTTP client
 | RTL10a | Supports all the same params as `RestChannel#history` |
 | RTL10c | Returns a `PaginatedResult` page containing the first page of messages |
 
-`RealtimeChannel#history` uses the same underlying REST endpoint as `RestChannel#history`. The tests in `uts/test/rest/unit/channel/history.md` (covering RSL2) should be used to verify that all the same behaviour, parameters, and return types apply when called on a `RealtimeChannel` instance.
+`RealtimeChannel#history` uses the same underlying REST endpoint as `RestChannel#history`. The tests in `uts/rest/unit/channel/history.md` (covering RSL2) should be used to verify that all the same behaviour, parameters, and return types apply when called on a `RealtimeChannel` instance.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_message_versions.md
+++ b/uts/realtime/unit/channels/channel_message_versions.md
@@ -13,4 +13,4 @@ Unit test with mocked HTTP client
 
 **Spec requirement:** `RealtimeChannel#getMessageVersions` function: same as `RestChannel#getMessageVersions`.
 
-`RealtimeChannel#getMessageVersions` uses the same underlying REST endpoint as `RestChannel#getMessageVersions`. The tests in `uts/test/rest/unit/channel/message_versions.md` (covering RSL14) should be used to verify that all the same behaviour, parameters, and return types apply when called on a `RealtimeChannel` instance.
+`RealtimeChannel#getMessageVersions` uses the same underlying REST endpoint as `RestChannel#getMessageVersions`. The tests in `uts/rest/unit/channel/message_versions.md` (covering RSL14) should be used to verify that all the same behaviour, parameters, and return types apply when called on a `RealtimeChannel` instance.

--- a/uts/realtime/unit/channels/channel_properties.md
+++ b/uts/realtime/unit/channels/channel_properties.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_publish.md
+++ b/uts/realtime/unit/channels/channel_publish.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_server_initiated_detach.md
+++ b/uts/realtime/unit/channels/channel_server_initiated_detach.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket and fake timers
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_state_events.md
+++ b/uts/realtime/unit/channels/channel_state_events.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_subscribe.md
+++ b/uts/realtime/unit/channels/channel_subscribe.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_update_delete_message.md
+++ b/uts/realtime/unit/channels/channel_update_delete_message.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/channel_when_state_test.md
+++ b/uts/realtime/unit/channels/channel_when_state_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/channels/message_field_population.md
+++ b/uts/realtime/unit/channels/message_field_population.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/client/realtime_client.md
+++ b/uts/realtime/unit/client/realtime_client.md
@@ -72,7 +72,7 @@ The same test cases apply:
 
 The Realtime client has the same error handling as the REST client for invalid credentials.
 
-**See:** `uts/test/realtime/unit/client/client_options.md` - RSC1b
+**See:** `uts/rest/unit/auth/auth_scheme.md` - RSC1b
 
 Error code 40106 should be raised when no valid credentials are provided.
 

--- a/uts/realtime/unit/client/realtime_client.md
+++ b/uts/realtime/unit/client/realtime_client.md
@@ -43,7 +43,7 @@ This means: if the state is already `connecting`, proceed immediately; otherwise
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 
@@ -613,11 +613,11 @@ The following options are shared with the REST client and should behave identica
 | `token` / `tokenDetails` | RSC1c | `uts/test/realtime/unit/client/client_options.md` |
 | `authCallback` / `authUrl` | RSA8 | `unit/auth/auth_callback.md` |
 | `clientId` | RSA7, RSC17 | `unit/auth/client_id.md` |
-| `tls` | RSC18 | `uts/test/rest/unit/rest_client.md` |
+| `tls` | RSC18 | `uts/rest/unit/rest_client.md` |
 | `environment` / `endpoint` | RSC15e, REC1 | `unit/client/fallback.md` |
 | `restHost` / `realtimeHost` | RSC12, TO3k2, TO3k3 | `unit/client/fallback.md` |
 | `fallbackHosts` | RSC15 | `unit/client/fallback.md` |
-| `useBinaryProtocol` | RSC8, TO3f | `uts/test/rest/unit/rest_client.md` |
+| `useBinaryProtocol` | RSC8, TO3f | `uts/rest/unit/rest_client.md` |
 | `logLevel` / `logHandler` | TO3b, TO3c | (not yet specified) |
 
 ### Realtime-Specific Verification for Shared Options
@@ -715,7 +715,7 @@ CLOSE_CLIENT(client)
 
 ## Test Infrastructure Notes
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for mock installation, test isolation, and timer mocking guidance.
+See `uts/realtime/unit/helpers/mock_websocket.md` for mock installation, test isolation, and timer mocking guidance.
 
 ### Channel Naming
 

--- a/uts/realtime/unit/client/realtime_request.md
+++ b/uts/realtime/unit/client/realtime_request.md
@@ -13,4 +13,4 @@ Unit test with mocked HTTP client
 
 **Spec requirement:** `RealtimeClient#request` is a wrapper around `RestClient#request` (see RSC19) delivered in an idiomatic way for the realtime library.
 
-`RealtimeClient#request` is a direct proxy to `RestClient#request`. The tests in `uts/test/rest/unit/request.md` (covering RSC19) should be used to test a `RealtimeClient` instance in place of a `RestClient` instance. All the same behaviour, parameters, and return types apply.
+`RealtimeClient#request` is a direct proxy to `RestClient#request`. The tests in `uts/rest/unit/request.md` (covering RSC19) should be used to test a `RealtimeClient` instance in place of a `RestClient` instance. All the same behaviour, parameters, and return types apply.

--- a/uts/realtime/unit/client/realtime_stats.md
+++ b/uts/realtime/unit/client/realtime_stats.md
@@ -16,4 +16,4 @@ Unit test with mocked HTTP client
 | RTC5a | Proxy to `RestClient#stats` presented with an async or threaded interface as appropriate |
 | RTC5b | Accepts all the same params as `RestClient#stats` and provides all the same functionality |
 
-`RealtimeClient#stats` is a direct proxy to `RestClient#stats`. The tests in `uts/test/rest/unit/stats.md` (covering RSC6) should be used to test a `RealtimeClient` instance in place of a `RestClient` instance. All the same behaviour, parameters, and return types apply.
+`RealtimeClient#stats` is a direct proxy to `RestClient#stats`. The tests in `uts/rest/unit/stats.md` (covering RSC6) should be used to test a `RealtimeClient` instance in place of a `RestClient` instance. All the same behaviour, parameters, and return types apply.

--- a/uts/realtime/unit/client/realtime_time.md
+++ b/uts/realtime/unit/client/realtime_time.md
@@ -15,4 +15,4 @@ Unit test with mocked HTTP client
 |------|-------------|
 | RTC6a | Proxy to `RestClient#time` presented with an async or threaded interface as appropriate |
 
-`RealtimeClient#time` is a direct proxy to `RestClient#time`. The tests in `uts/test/rest/unit/time.md` (covering RSC16) should be used to test a `RealtimeClient` instance in place of a `RestClient` instance. All the same behaviour, parameters, and return types apply.
+`RealtimeClient#time` is a direct proxy to `RestClient#time`. The tests in `uts/rest/unit/time.md` (covering RSC16) should be used to test a `RealtimeClient` instance in place of a `RestClient` instance. All the same behaviour, parameters, and return types apply.

--- a/uts/realtime/unit/client/realtime_timeouts.md
+++ b/uts/realtime/unit/client/realtime_timeouts.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/connection/auto_connect_test.md
+++ b/uts/realtime/unit/connection/auto_connect_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/connection/backoff_jitter_test.md
+++ b/uts/realtime/unit/connection/backoff_jitter_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ## Overview
 

--- a/uts/realtime/unit/connection/connection_failures_test.md
+++ b/uts/realtime/unit/connection/connection_failures_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/connection/connection_id_key_test.md
+++ b/uts/realtime/unit/connection/connection_id_key_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/connection/connection_open_failures_test.md
+++ b/uts/realtime/unit/connection/connection_open_failures_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/connection/connection_ping_test.md
+++ b/uts/realtime/unit/connection/connection_ping_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ## Overview
 

--- a/uts/realtime/unit/connection/connection_recovery_test.md
+++ b/uts/realtime/unit/connection/connection_recovery_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/connection/error_reason_test.md
+++ b/uts/realtime/unit/connection/error_reason_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/connection/fallback_hosts_test.md
+++ b/uts/realtime/unit/connection/fallback_hosts_test.md
@@ -7,8 +7,8 @@ Unit test with mocked WebSocket client and HTTP client
 
 ## Mock Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
-See `uts/test/rest/unit/helpers/mock_http.md` for Mock HTTP Client specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/rest/unit/helpers/mock_http.md` for Mock HTTP Client specification.
 
 ---
 

--- a/uts/realtime/unit/connection/forwards_compatibility_test.md
+++ b/uts/realtime/unit/connection/forwards_compatibility_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ## Overview
 

--- a/uts/realtime/unit/connection/heartbeat_test.md
+++ b/uts/realtime/unit/connection/heartbeat_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ## Overview
 

--- a/uts/realtime/unit/connection/network_change_test.md
+++ b/uts/realtime/unit/connection/network_change_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ## Platform Network Connectivity Listener
 

--- a/uts/realtime/unit/connection/server_initiated_reauth_test.md
+++ b/uts/realtime/unit/connection/server_initiated_reauth_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client and authCallback
 
 ## Mock Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ## Purpose
 

--- a/uts/realtime/unit/connection/update_events_test.md
+++ b/uts/realtime/unit/connection/update_events_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/realtime/unit/connection/when_state_test.md
+++ b/uts/realtime/unit/connection/when_state_test.md
@@ -7,7 +7,7 @@ Unit test with mocked WebSocket client
 
 ## Mock WebSocket Infrastructure
 
-See `uts/test/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
+See `uts/realtime/unit/helpers/mock_websocket.md` for the full Mock WebSocket Infrastructure specification.
 
 ---
 

--- a/uts/rest/integration/proxy/rest_fallback.md
+++ b/uts/rest/integration/proxy/rest_fallback.md
@@ -13,7 +13,7 @@ See `uts/realtime/integration/helpers/proxy.md` for the full proxy infrastructur
 ## Corresponding Unit Tests
 
 - `uts/rest/unit/fallback.md` -- RSC15l/RSC15l4 (unit test verifies fallback logic with mocked HTTP)
-- `uts/rest/unit/publish.md` -- RSL1k (unit test verifies idempotent publish logic with mocked HTTP)
+- `uts/rest/unit/channel/idempotency.md` -- RSL1k (unit test verifies idempotent publish logic with mocked HTTP)
 
 ## Purpose
 

--- a/uts/rest/unit/auth/auth_callback.md
+++ b/uts/rest/unit/auth/auth_callback.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
+See `uts/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
 
 ## Purpose
 

--- a/uts/rest/unit/auth/auth_scheme.md
+++ b/uts/rest/unit/auth/auth_scheme.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
+See `uts/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
 
 ## Purpose
 

--- a/uts/rest/unit/auth/authorize.md
+++ b/uts/rest/unit/auth/authorize.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client and/or mocked authCallback
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
+See `uts/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
 
 ---
 

--- a/uts/rest/unit/auth/client_id.md
+++ b/uts/rest/unit/auth/client_id.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client and/or authCallback
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
+See `uts/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
 
 ---
 

--- a/uts/rest/unit/auth/revoke_tokens.md
+++ b/uts/rest/unit/auth/revoke_tokens.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
+See `uts/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
 
 ## Server Response Format
 

--- a/uts/rest/unit/auth/token_details.md
+++ b/uts/rest/unit/auth/token_details.md
@@ -15,7 +15,7 @@ Unit test with mocked HTTP client and/or mocked authCallback
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification.
+See `uts/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification.
 
 ---
 

--- a/uts/rest/unit/auth/token_renewal.md
+++ b/uts/rest/unit/auth/token_renewal.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
+See `uts/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
 
 ## Purpose
 

--- a/uts/rest/unit/auth/token_request_params.md
+++ b/uts/rest/unit/auth/token_request_params.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
+See `uts/rest/unit/rest_client.md` for the full Mock HTTP Infrastructure specification. These tests use the same `MockHttpClient` interface with `PendingConnection` and `PendingRequest`.
 
 ## Purpose
 

--- a/uts/rest/unit/channel/annotations.md
+++ b/uts/rest/unit/channel/annotations.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-These tests use the mock HTTP infrastructure defined in `uts/test/rest/unit/helpers/mock_http.md`.
+These tests use the mock HTTP infrastructure defined in `uts/rest/unit/helpers/mock_http.md`.
 
 ---
 

--- a/uts/rest/unit/channel/get_message.md
+++ b/uts/rest/unit/channel/get_message.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-These tests use the mock HTTP infrastructure defined in `uts/test/rest/unit/helpers/mock_http.md`.
+These tests use the mock HTTP infrastructure defined in `uts/rest/unit/helpers/mock_http.md`.
 
 ---
 

--- a/uts/rest/unit/channel/history.md
+++ b/uts/rest/unit/channel/history.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-These tests use the mock HTTP infrastructure defined in `/Users/paddy/data/worknew/dev/dart-experiments/uts/test/rest/unit/rest_client.md`.
+These tests use the mock HTTP infrastructure defined in `/Users/paddy/data/worknew/dev/dart-experiments/uts/rest/unit/rest_client.md`.
 
 The mock must support:
 - Handler-based configuration with `onConnectionAttempt` and `onRequest` callbacks

--- a/uts/rest/unit/channel/idempotency.md
+++ b/uts/rest/unit/channel/idempotency.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-These tests use the mock HTTP infrastructure defined in `/Users/paddy/data/worknew/dev/dart-experiments/uts/test/rest/unit/rest_client.md`.
+These tests use the mock HTTP infrastructure defined in `/Users/paddy/data/worknew/dev/dart-experiments/uts/rest/unit/rest_client.md`.
 
 The mock must support:
 - Handler-based configuration with `onConnectionAttempt` and `onRequest` callbacks

--- a/uts/rest/unit/channel/message_versions.md
+++ b/uts/rest/unit/channel/message_versions.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-These tests use the mock HTTP infrastructure defined in `uts/test/rest/unit/helpers/mock_http.md`.
+These tests use the mock HTTP infrastructure defined in `uts/rest/unit/helpers/mock_http.md`.
 
 ---
 

--- a/uts/rest/unit/channel/publish.md
+++ b/uts/rest/unit/channel/publish.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-These tests use the mock HTTP infrastructure defined in `/Users/paddy/data/worknew/dev/dart-experiments/uts/test/rest/unit/rest_client.md`.
+These tests use the mock HTTP infrastructure defined in `/Users/paddy/data/worknew/dev/dart-experiments/uts/rest/unit/rest_client.md`.
 
 The mock must support:
 - Handler-based configuration with `onConnectionAttempt` and `onRequest` callbacks

--- a/uts/rest/unit/channel/publish_result.md
+++ b/uts/rest/unit/channel/publish_result.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-These tests use the mock HTTP infrastructure defined in `uts/test/rest/unit/helpers/mock_http.md`.
+These tests use the mock HTTP infrastructure defined in `uts/rest/unit/helpers/mock_http.md`.
 
 ---
 

--- a/uts/rest/unit/channel/rest_channel_attributes.md
+++ b/uts/rest/unit/channel/rest_channel_attributes.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
+See `uts/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
 
 ---
 

--- a/uts/rest/unit/channel/update_delete_message.md
+++ b/uts/rest/unit/channel/update_delete_message.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-These tests use the mock HTTP infrastructure defined in `uts/test/rest/unit/helpers/mock_http.md`.
+These tests use the mock HTTP infrastructure defined in `uts/rest/unit/helpers/mock_http.md`.
 
 ---
 

--- a/uts/rest/unit/encoding/message_encoding.md
+++ b/uts/rest/unit/encoding/message_encoding.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-These tests use the mock HTTP infrastructure described in `/Users/paddy/data/worknew/dev/dart-experiments/uts/test/rest/unit/rest_client.md`.
+These tests use the mock HTTP infrastructure described in `/Users/paddy/data/worknew/dev/dart-experiments/uts/rest/unit/rest_client.md`.
 
 The mock supports:
 - Intercepting HTTP requests and capturing details (URL, headers, method, body)

--- a/uts/rest/unit/presence/rest_presence.md
+++ b/uts/rest/unit/presence/rest_presence.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-These tests use the mock HTTP infrastructure described in `/Users/paddy/data/worknew/dev/dart-experiments/uts/test/rest/unit/rest_client.md`.
+These tests use the mock HTTP infrastructure described in `/Users/paddy/data/worknew/dev/dart-experiments/uts/rest/unit/rest_client.md`.
 
 The mock supports:
 - Intercepting HTTP requests and capturing details (URL, headers, method, body)

--- a/uts/rest/unit/push/push_admin_publish.md
+++ b/uts/rest/unit/push/push_admin_publish.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
+See `uts/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
 
 ---
 

--- a/uts/rest/unit/push/push_channel_subscriptions.md
+++ b/uts/rest/unit/push/push_channel_subscriptions.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
+See `uts/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
 
 ---
 

--- a/uts/rest/unit/push/push_channels.md
+++ b/uts/rest/unit/push/push_channels.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
+See `uts/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
 
 ## Notes
 

--- a/uts/rest/unit/push/push_device_registrations.md
+++ b/uts/rest/unit/push/push_device_registrations.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
+See `uts/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
 
 ---
 

--- a/uts/rest/unit/request_endpoint.md
+++ b/uts/rest/unit/request_endpoint.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
+See `uts/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
 
 ---
 

--- a/uts/rest/unit/rest_client.md
+++ b/uts/rest/unit/rest_client.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
+See `uts/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
 
 ---
 
@@ -587,4 +587,4 @@ ASSERT result IS valid
 
 ## Test Infrastructure Notes
 
-See `uts/test/rest/unit/helpers/mock_http.md` for mock installation, test isolation, and timer mocking guidance.
+See `uts/rest/unit/helpers/mock_http.md` for mock installation, test isolation, and timer mocking guidance.

--- a/uts/rest/unit/stats.md
+++ b/uts/rest/unit/stats.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-See `uts/test/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
+See `uts/rest/unit/helpers/mock_http.md` for the full Mock HTTP Infrastructure specification.
 
 ## Purpose
 

--- a/uts/rest/unit/types/paginated_result.md
+++ b/uts/rest/unit/types/paginated_result.md
@@ -7,7 +7,7 @@ Unit test with mocked HTTP client
 
 ## Mock HTTP Infrastructure
 
-These tests use the mock HTTP infrastructure described in `/Users/paddy/data/worknew/dev/dart-experiments/uts/test/rest/unit/rest_client.md`.
+These tests use the mock HTTP infrastructure described in `/Users/paddy/data/worknew/dev/dart-experiments/uts/rest/unit/rest_client.md`.
 
 The mock supports:
 - Intercepting HTTP requests and capturing details (URL, headers, method, body)


### PR DESCRIPTION
## Intent

The UTS specs were authored against a planned `uts/test/<module>/` directory layout that never shipped — the tree landed as `uts/<module>/`. As a result, **91 cross-references across 75 spec files** still point at paths that have never existed in this repository, so anyone (or any tooling) following them finds a dead path. This PR is the mechanical cleanup, discovered while fixing the objects proxy specs (#501).

## What changed

**Commit 1** — a pure `uts/test/<path>` → `uts/<path>` rewrite, **applied only where the corrected target file was verified to exist** (each of the 26 unique referenced paths was checked before rewriting). No content changes — 90 insertions / 90 deletions, one-for-one. The bulk is repeated boilerplate header lines:

| Referenced file | Occurrences |
|---|---|
| `realtime/unit/helpers/mock_websocket.md` | 36 |
| `rest/unit/helpers/mock_http.md` | 16 |
| `rest/unit/rest_client.md` | 15 |
| 23 other unit specs / helpers | 24 |

**Commit 2** — two additional broken cross-references found by validating *every* backticked `uts/*.md` path in the tree (not just the `uts/test/` class), each retargeted to verified coverage:

- `rest_fallback.md`: RSL1k pointed at nonexistent `uts/rest/unit/publish.md` → now `uts/rest/unit/channel/idempotency.md` (where the idempotent-publish unit coverage actually lives)
- `realtime_client.md`: the RSC1b pointer targeted the never-written `client_options.md` → now `uts/rest/unit/auth/auth_scheme.md` (`rest/unit/RSC1b/no-auth-method-error-0`)

## Deliberately excluded (and why)

1. **Proxy infrastructure references** (`uts/test/realtime/integration/helpers/proxy.md` in the 7 realtime proxy specs, and two `uts/test/proxy/` directory mentions) — those exact lines are rewritten by the proxy.md relocation commit on `fix/uts-proxy-liveobjects-spec` (#501 chain). Fixing them here as well would only manufacture merge conflicts; they are covered there.
2. **Three references to `client_options.md`** in `realtime/unit/client/realtime_client.md` (the RSC1/RSC1a/RSC1c "See:" line and the two constructor-table rows) — this file has never existed under any layout, and **no REST-side spec covers key-vs-token constructor detection** (`RSC1a` appears only in `completion-status.md` and `realtime_client.md` itself). These are left in place deliberately: they mark a genuine coverage gap for a spec owner to resolve — either write the planned REST constructor spec or amend the sections and `completion-status.md` — rather than a path to rewrite. A rewrite would merely hide the gap.

## Verification

- Every rewritten reference resolves to an existing file (validated per unique path pre-rewrite).
- Post-rewrite sweep: a repo-wide validation of every backticked `uts/*.md` path leaves exactly two unresolved classes — the proxy references owned by #501 and the three flagged `client_options.md` references.
- `git diff --check` clean; no spec content touched beyond the path strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)