### PR TITLE
[AIT-1138] Deprecate RTPO8d: `PathObject#instance` wraps primitives (RTPO8f)

### DIFF
--- a/specifications/objects-features.md
+++ b/specifications/objects-features.md
@@ -912,8 +912,9 @@ A `PathObject` is obtained from `RealtimeObject#get` ([RTO23](#RTO23)), which re
   - `(RTPO8a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTPO8b)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3))
   - `(RTPO8c)` If the resolved value is a `LiveObject` (i.e. a `LiveMap` or `LiveCounter`), returns a new `Instance` ([RTINS1](#RTINS1)) wrapping that `LiveObject`
-  - `(RTPO8d)` If the resolved value is a primitive, returns undefined/null
+  - `(RTPO8d)` This clause has been replaced by [RTPO8f](#RTPO8f).
   - `(RTPO8e)` If path resolution fails, returns undefined/null per [RTPO3c1](#RTPO3c1)
+  - `(RTPO8f)` If the resolved value is a primitive, returns a new `Instance` ([RTINS1](#RTINS1)) wrapping the primitive value
 - `(RTPO9)` `PathObject#entries` function:
   - `(RTPO9a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTPO9b)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3))

--- a/specifications/objects-features.md
+++ b/specifications/objects-features.md
@@ -913,8 +913,8 @@ A `PathObject` is obtained from `RealtimeObject#get` ([RTO23](#RTO23)), which re
   - `(RTPO8b)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3))
   - `(RTPO8c)` If the resolved value is a `LiveObject` (i.e. a `LiveMap` or `LiveCounter`), returns a new `Instance` ([RTINS1](#RTINS1)) wrapping that `LiveObject`
   - `(RTPO8d)` This clause has been replaced by [RTPO8f](#RTPO8f).
+  - `(RTPO8f)` If the resolved value is a primitive (`Boolean`, `Binary`, `Number`, `String`, `JsonArray`, `JsonObject`), returns a new `Instance` ([RTINS1](#RTINS1)) wrapping the primitive value
   - `(RTPO8e)` If path resolution fails, returns undefined/null per [RTPO3c1](#RTPO3c1)
-  - `(RTPO8f)` If the resolved value is a primitive, returns a new `Instance` ([RTINS1](#RTINS1)) wrapping the primitive value
 - `(RTPO9)` `PathObject#entries` function:
   - `(RTPO9a)` Checks the access API preconditions per [RTO25](#RTO25)
   - `(RTPO9b)` Resolves the path using the path resolution procedure ([RTPO3](#RTPO3))

--- a/uts/objects/unit/path_object.md
+++ b/uts/objects/unit/path_object.md
@@ -276,14 +276,16 @@ ASSERT map_inst.id() == "map:profile@1000"
 
 ---
 
-## RTPO8c - instance() returns null for primitive
+## RTPO8f - instance() returns Instance for primitive
 
-**Test ID**: `objects/unit/RTPO8c/instance-primitive-null-0`
+**Test ID**: `objects/unit/RTPO8f/instance-primitive-wrapped-0`
 
 | Spec | Requirement |
 |------|-------------|
 | RTPO8a | Checks access API preconditions per RTO25 |
-| RTPO8d | Primitive -> returns null |
+| RTPO8f | Primitive -> Instance wrapping the primitive value |
+| RTINS3b | Primitive Instance has no object id |
+| RTINS4c | Instance#value returns the primitive value directly |
 
 ### Setup
 ```pseudo
@@ -292,7 +294,10 @@ ASSERT map_inst.id() == "map:profile@1000"
 
 ### Assertions
 ```pseudo
-ASSERT root.get("name").instance() == null
+name_inst = root.get("name").instance()
+ASSERT name_inst IS Instance
+ASSERT name_inst.id() == null
+ASSERT name_inst.value() == "Alice"
 ```
 
 ---


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/AIT-1138

## What

`PathObject#instance` previously returned undefined/null when the path resolved to a primitive value (`RTPO8d`). This PR deprecates that clause and replaces it with `RTPO8f`: a primitive resolution now returns a new `Instance` wrapping the primitive value. The corresponding UTS test spec is updated to match.

## Why

The primitive-null behaviour was the odd one out in the `Instance` model:

- `RTINS1` already defines `Instance` as "a direct-reference view of a `LiveObject` **or primitive value**".
- Primitives already surface as `Instance`s through `Instance#get` (`RTINS5c`), so a map entry read via an `Instance` produced a primitive `Instance`, while the same entry read via `PathObject#instance` produced nothing.
- `RTINS3b` (primitives have no object id) and `RTINS4c` (`Instance#value` returns the primitive directly) already specify how a primitive-wrapping `Instance` behaves — `RTPO8d` was just blocking the one entry point.

Making `instance()` total over resolved values gives callers a single, uniform way to capture a point-in-time reference to whatever sits at a path.

## Changes

### `specifications/objects-features.md`

- `RTPO8d` — marked as replaced by `RTPO8f`, following the existing deprecation convention.
- `RTPO8f` (new) — a primitive resolution returns a new `Instance` (`RTINS1`) wrapping the primitive value.
- `RTPO8c` (LiveObject → `Instance`) and `RTPO8e` (resolution failure → undefined/null) are unchanged.

### `uts/objects/unit/path_object.md`

- `objects/unit/RTPO8c/instance-primitive-null-0` becomes `objects/unit/RTPO8f/instance-primitive-wrapped-0`: asserts the returned `Instance` exists, has no object id (`RTINS3b`), and exposes the primitive via `value()` (`RTINS4c`).

## SDK adoption

Both SDK implementations and their derived UTS tests have been updated to this behaviour and are pending on their respective branches:

- **ably-js**: `_resolveInstance` wraps any resolved value; `batch()` retains its explicit LiveObject check so the 92007 non-LiveObject error is unaffected.
- **ably-java**: `DefaultPathObject.instance()` returns the typed `Instance` for any resolved value; primitive instances remain anonymous (no `id` member) per the typed-SDK contract.

## Follow-up (separate PR)

The typed-SDK spec section (`RTTS6e` / `RTTS3b`, #491) still states that `instance()` on primitive `PathObject` sub-classes returns null or throws 92007 — that premise is removed by this change and will be reconciled in an individual PR against that branch.