### PR TITLE
[AIT-1141] fix(uts/objects): spec-side corrections from the LiveObjects deviations audit

### DIFF
--- a/uts/README.md
+++ b/uts/README.md
@@ -95,6 +95,10 @@ Pseudocode maps to language idioms rather than prescribing exact syntax:
 - **Property access**: member access written as a call (e.g. `instance.id()`) is satisfied by a
   property or getter (`instance.id`) where the SDK's feature spec defines the member as a
   property (e.g. `Instance#id`, RTINS3).
+- **Enum values**: a symbolic enum value in pseudo-code (e.g. `"LWW"` for
+  `ObjectsMapSemantics.LWW`, wire-encoded as an integer per OMP2) is satisfied by the SDK's
+  idiomatic public rendering of that enum member — the enum member itself in typed SDKs
+  (`MapSemantics.LWW` in ably-java), or a string-literal union value in ably-js (`'lww'`).
 - **Language-inapplicable inputs**: a test input that cannot be constructed in a given language
   (e.g. a non-string map key in JavaScript, where object keys are always coerced to strings; or a
   `null` argument where the SDK's signature makes null indistinguishable from "omitted") makes

--- a/uts/README.md
+++ b/uts/README.md
@@ -99,6 +99,24 @@ Pseudocode maps to language idioms rather than prescribing exact syntax:
   `ObjectsMapSemantics.LWW`, wire-encoded as an integer per OMP2) is satisfied by the SDK's
   idiomatic public rendering of that enum member — the enum member itself in typed SDKs
   (`MapSemantics.LWW` in ably-java), or a string-literal union value in ably-js (`'lww'`).
+- **`poll_until_success(condition)`**: a `poll_until` (interval 500ms, timeout 10s) that keeps
+  polling until the condition succeeds — returns a truthy result without raising. Any error raised by
+  the condition — not-found for a not-yet-visible write, or a transient service/network error —
+  means "keep polling" rather than failure; if the timeout expires, the most recent error is
+  raised so the failure stays diagnosable (a plain timeout error if the condition never raised).
+  Use only where an error genuinely means "not ready yet", e.g. reads of the eventually-consistent
+  message store (`getMessage`, `getMessageVersions`, `annotations.get`), or LiveObjects value
+  reads polled across a fault-injection/recovery window, where the channel is transiently
+  DETACHED and reads raise by design; where an error should fail the test, use `poll_until`.
+  Implementations typically provide this as a shared helper wrapping their `poll_until`
+  (e.g. `pollUntilSuccess` in ably-js); the reference definition lives in
+  [docs/writing-test-specs.md](docs/writing-test-specs.md).
+- **`flush_async()`**: drain pending event-loop work (microtasks and zero-delay callbacks)
+  without any real delay — used at unit tier to let mock events propagate before asserting,
+  especially for negative assertions ("nothing happened"). Never rendered as a timed sleep;
+  implementations define a shared helper (e.g. `flushAsync()` in ably-js, awaiting a
+  `setImmediate`) — see the timer guidance in
+  [docs/writing-derived-tests.md](docs/writing-derived-tests.md).
 - **Language-inapplicable inputs**: a test input that cannot be constructed in a given language
   (e.g. a non-string map key in JavaScript, where object keys are always coerced to strings; or a
   `null` argument where the SDK's signature makes null indistinguishable from "omitted") makes

--- a/uts/README.md
+++ b/uts/README.md
@@ -111,12 +111,13 @@ Pseudocode maps to language idioms rather than prescribing exact syntax:
   Implementations typically provide this as a shared helper wrapping their `poll_until`
   (e.g. `pollUntilSuccess` in ably-js); the reference definition lives in
   [docs/writing-test-specs.md](docs/writing-test-specs.md).
-- **`flush_async()`**: drain pending event-loop work (microtasks and zero-delay callbacks)
-  without any real delay — used at unit tier to let mock events propagate before asserting,
-  especially for negative assertions ("nothing happened"). Never rendered as a timed sleep;
-  implementations define a shared helper (e.g. `flushAsync()` in ably-js, awaiting a
-  `setImmediate`) — see the timer guidance in
-  [docs/writing-derived-tests.md](docs/writing-derived-tests.md).
+- **`process_pending_events()`**: let the client finish processing all asynchronous work that
+  is already queued (mock events, promise continuations) before the test continues — used at
+  unit tier before asserting, especially for negative assertions ("nothing happened"). Involves
+  no real delay and is never rendered as a timed sleep; implementations define a shared helper
+  using the platform's zero-delay yield (e.g. `flushAsync()` awaiting a `setImmediate` in
+  ably-js, or `runCurrent()` on a kotlinx-coroutines test scheduler) — see the timer guidance
+  in [docs/writing-derived-tests.md](docs/writing-derived-tests.md).
 - **Language-inapplicable inputs**: a test input that cannot be constructed in a given language
   (e.g. a non-string map key in JavaScript, where object keys are always coerced to strings; or a
   `null` argument where the SDK's signature makes null indistinguishable from "omitted") makes

--- a/uts/README.md
+++ b/uts/README.md
@@ -87,6 +87,20 @@ ASSERT error.code == 40160
 AWAIT_STATE client.connection.state == ConnectionState.connected
 ```
 
+Pseudocode maps to language idioms rather than prescribing exact syntax:
+
+- **Absent values**: `== null` means the language-appropriate "absent" value — `undefined` in
+  JavaScript, `null` in Java/Kotlin/Swift. Assertions like `ASSERT x.value() == null` are
+  satisfied by `undefined` in SDKs where that is the idiomatic absent value.
+- **Property access**: member access written as a call (e.g. `instance.id()`) is satisfied by a
+  property or getter (`instance.id`) where the SDK's feature spec defines the member as a
+  property (e.g. `Instance#id`, RTINS3).
+- **Language-inapplicable inputs**: a test input that cannot be constructed in a given language
+  (e.g. a non-string map key in JavaScript, where object keys are always coerced to strings; or a
+  `null` argument where the SDK's signature makes null indistinguishable from "omitted") makes
+  that test — or that table row — not applicable to that SDK. Such omissions are sanctioned and
+  should be noted in the derived test file rather than counted as coverage gaps.
+
 See [docs/writing-test-specs.md](docs/writing-test-specs.md) for the full pseudocode reference, mock patterns, and conventions.
 
 ## Guides

--- a/uts/docs/writing-derived-tests.md
+++ b/uts/docs/writing-derived-tests.md
@@ -39,6 +39,8 @@ UTS specs use generic pseudocode. You need to map this onto the SDK's actual API
 | `enable_fake_timers()` | Timer control mechanism |
 | `ADVANCE_TIME(ms)` | Fake timer tick method |
 | `AWAIT_STATE(connection, "connected")` | State waiting helper |
+| `poll_until(condition, ...)` | Shared polling helper (wall-clock deadline — see below) |
+| `poll_until_success(condition)` | Error-tolerant polling helper (see the pseudocode conventions in `uts/README.md`) |
 
 Check the SDK's existing test infrastructure and conventions before writing anything. Reuse existing helpers, mock classes, and patterns.
 
@@ -288,6 +290,15 @@ Kotlin), or use the framework's escape hatch for real time. Define shared helper
 (`awaitState`, `pollUntil`, `withRealTimeout`, ...) that encapsulate this once, and use them for
 every wait in integration test bodies. Unit tests are unaffected — there, fake/virtual timers
 remain the preferred mechanism.
+
+The same trap exists at unit tier in the other direction: a harness `poll_until` whose deadline
+reads a clock the test itself stubs will never expire. For example, a deadline computed from
+`Date.now()` freezes in a JavaScript test that stubs `Date.now` for fake-time advancement — the
+poll spins until the runner's own timeout kills it with a generic error instead of the poll's
+informative one. Two remedies: restructure the test so the wall clock never needs stubbing
+(preferred — e.g. backdate a fixture timestamp past the period under test instead of advancing
+a fake "now"), or have harness deadlines read a monotonic clock that test-level time stubbing
+cannot touch (`performance.now()` in JavaScript, `System.nanoTime()` on the JVM).
 
 ### Cleanup with afterEach
 

--- a/uts/docs/writing-derived-tests.md
+++ b/uts/docs/writing-derived-tests.md
@@ -253,7 +253,7 @@ These casts are an SDK wart, not a test problem — apply them as needed and mov
 Unit tests must not use real timers (`setTimeout`, `setInterval`, `sleep`, `delay`) to wait for asynchronous events. Real timers make tests slow, flaky, and prevent the process from exiting cleanly.
 
 - **For time-dependent SDK behaviour** (timeouts, retries, heartbeats): use fake timers that replace the SDK's timer API and can be advanced deterministically.
-- **For waiting on async event delivery** (mock message propagation, promise settlement): yield to the event loop with a zero-delay mechanism like `setImmediate`, `process.nextTick`, or equivalent. Define a `flushAsync()` helper and use it everywhere instead of `setTimeout(resolve, N)`.
+- **For waiting on async event delivery** (mock message propagation, promise settlement): yield to the event loop with a zero-delay mechanism like `setImmediate`, `process.nextTick`, or equivalent. Define a `flushAsync()` helper and use it everywhere instead of `setTimeout(resolve, N)`. This is the rendering of the spec's `process_pending_events()` convention (see `uts/README.md`).
 - **For "prove a negative" assertions** (confirming something did NOT happen): a single event-loop yield is sufficient — if the event hasn't fired after one pass through the macrotask queue, it won't fire from the current stimulus.
 
 The only acceptable use of a real timer is a **safety timeout on test execution** — a long deadline (e.g. 5 seconds) that fails the test if an expected event never arrives, preventing the test from hanging indefinitely. This is a test-level safeguard, not a delay mechanism.
@@ -269,6 +269,28 @@ await flushAsync();
 const timer = setTimeout(() => reject(new Error('Timed out')), 5000);
 connection.once('connected', () => { clearTimeout(timer); resolve(); });
 ```
+
+**Fake time and poll deadlines collide.** A safety timeout or a `poll_until` helper whose
+deadline reads a clock the test's fake timers stub will never expire. This is easy to hit,
+because mainstream fake-timer tools fake the wall clock by default (Jest's modern fake timers
+and sinon's `useFakeTimers` both mock `Date`): a deadline computed from `Date.now()` freezes
+while fake time is installed, so the poll spins until the runner's own timeout kills it with a
+generic error instead of the poll's informative one. Two remedies, in order of preference:
+
+1. **Restructure the test so the wall clock never needs stubbing**: backdate a fixture
+   timestamp past the period under test instead of advancing a fake "now". For example,
+   ably-js's derived RTO10/RTO10b1 GC tests render the spec's `ADVANCE_TIME`
+   (`objects/unit/realtime_object.md`) by stamping the tombstone's `serialTimestamp` in the
+   past (RTLO6a makes it `tombstonedAt`), so the object is already GC-eligible under the real
+   clock and nothing is stubbed.
+2. **Have the polling helper's deadline read a monotonic clock** that time stubbing cannot
+   touch: `performance.now()` in JavaScript, `System.nanoTime()` on the JVM.
+
+A *synchronous* stub window is exempt: stubbing the clock around a single non-awaiting call and
+restoring it in a `finally` never overlaps a poll, so the trap cannot fire. Sometimes it is the
+only option — the SDK reads the clock internally and the spec fixture is a fixed epoch, as in
+RTLM19's GC-boundary test — and it should then be recorded as a deviation in the test file
+header.
 
 ### Integration timeouts are wall-clock (beware virtual-time frameworks)
 
@@ -290,15 +312,6 @@ Kotlin), or use the framework's escape hatch for real time. Define shared helper
 (`awaitState`, `pollUntil`, `withRealTimeout`, ...) that encapsulate this once, and use them for
 every wait in integration test bodies. Unit tests are unaffected — there, fake/virtual timers
 remain the preferred mechanism.
-
-The same trap exists at unit tier in the other direction: a harness `poll_until` whose deadline
-reads a clock the test itself stubs will never expire. For example, a deadline computed from
-`Date.now()` freezes in a JavaScript test that stubs `Date.now` for fake-time advancement — the
-poll spins until the runner's own timeout kills it with a generic error instead of the poll's
-informative one. Two remedies: restructure the test so the wall clock never needs stubbing
-(preferred — e.g. backdate a fixture timestamp past the period under test instead of advancing
-a fake "now"), or have harness deadlines read a monotonic clock that test-level time stubbing
-cannot touch (`performance.now()` in JavaScript, `System.nanoTime()` on the JVM).
 
 ### Cleanup with afterEach
 

--- a/uts/docs/writing-test-specs.md
+++ b/uts/docs/writing-test-specs.md
@@ -752,7 +752,7 @@ ADVANCE_TIME(3000)
 AWAIT_STATE state == disconnected
 ```
 
-Reference definition of `poll_until` (a shared helper in each SDK's test harness). Specs call it
+Reference definition of `poll_until` (a shared helper in each SDK's test suite). Specs call it
 with either a bare condition expression (re-evaluated each iteration until true) or a producer
 function whose first truthy result is returned:
 
@@ -768,9 +768,19 @@ FUNCTION poll_until(condition, interval: 500ms, timeout: 10s):
     WAIT interval
 ```
 
-At integration tier the deadline and interval are wall-clock time; unit-tier harnesses may
-realise the interval as event-loop turns instead of real sleeps (see *Integration timeouts are
+At integration tier the deadline and interval are wall-clock time; unit-tier implementations
+may realise the interval as event-loop turns instead of real sleeps (see *Integration timeouts are
 wall-clock* in `writing-derived-tests.md` for the traps on both sides).
+
+For a **negative assertion** at unit tier — proving something did *not* happen — there is
+nothing to poll for: use `process_pending_events()` (see the pseudocode conventions in
+`uts/README.md`) to let already-queued events settle, then assert. Never a fixed `WAIT`.
+
+```pseudo
+# Good - negative assertion: settle pending events, then assert nothing happened
+process_pending_events()
+ASSERT mock_ws.connect_attempts.length == 0
+```
 
 **A `poll_until` fails immediately if its condition raises an error.** For reads that are expected
 to fail until the service catches up — reads of the eventually-consistent message store

--- a/uts/docs/writing-test-specs.md
+++ b/uts/docs/writing-test-specs.md
@@ -752,6 +752,67 @@ ADVANCE_TIME(3000)
 AWAIT_STATE state == disconnected
 ```
 
+Reference definition of `poll_until` (a shared helper in each SDK's test harness). Specs call it
+with either a bare condition expression (re-evaluated each iteration until true) or a producer
+function whose first truthy result is returned:
+
+```pseudo
+FUNCTION poll_until(condition, interval: 500ms, timeout: 10s):
+  deadline = now() + timeout
+  WHILE true:
+    result = AWAIT condition()   # an error raised here aborts the poll immediately
+    IF result:                   # truthy: condition met / value produced
+      RETURN result
+    IF now() >= deadline:
+      RAISE TimeoutError("poll_until timed out after " + timeout)
+    WAIT interval
+```
+
+At integration tier the deadline and interval are wall-clock time; unit-tier harnesses may
+realise the interval as event-loop turns instead of real sleeps (see *Integration timeouts are
+wall-clock* in `writing-derived-tests.md` for the traps on both sides).
+
+**A `poll_until` fails immediately if its condition raises an error.** For reads that are expected
+to fail until the service catches up — reads of the eventually-consistent message store
+(`getMessage`, `getMessageVersions`, `annotations.get`) throw not-found until a just-written
+message becomes visible, and LiveObjects value reads raise while a fault-injection test's
+channel is transiently DETACHED mid-recovery — use `poll_until_success` instead: any error raised by the condition
+means "keep polling", and if the timeout expires the most recent error is raised so the failure
+stays diagnosable. The convention is also summarised in the pseudocode conventions in `uts/README.md`.
+
+```pseudo
+# Good - store read polled through its expected not-found errors
+msg = poll_until_success(
+  condition: FUNCTION() =>
+    m = AWAIT channel.getMessage(serial)
+    IF m.action == MessageAction.MESSAGE_UPDATE:
+      RETURN m
+    RETURN null
+)
+```
+
+Reference definition (implement once as a shared helper, typically wrapping `poll_until`):
+
+```pseudo
+FUNCTION poll_until_success(condition, interval: 500ms, timeout: 10s):
+  last_error = null
+  deadline = now() + timeout
+  WHILE true:
+    TRY:
+      result = AWAIT condition()
+      IF result:               # truthy: condition met / value produced
+        RETURN result
+    CATCH error:
+      last_error = error   # any error means "not ready yet" - keep polling
+    IF now() >= deadline:
+      # raise the most recent error so the failure stays diagnosable;
+      # a plain timeout error only if the condition never raised
+      IF last_error != null:
+        RAISE last_error
+      RAISE TimeoutError("poll_until_success timed out after " + timeout)
+    WAIT interval
+```
+
 ### Verifying Transient States (Record-and-Verify Pattern)
 
 **When testing disconnect/reconnect behavior, always use the record-and-verify pattern.** Do not use intermediate `AWAIT_STATE` calls to observe transient states like DISCONNECTED or SUSPENDED mid-test. The Ably spec mandates immediate reconnection on unexpected disconnect (RTN15a), which means transient states pass too quickly to be reliably observed between test steps.

--- a/uts/objects/helpers/standard_test_pool.md
+++ b/uts/objects/helpers/standard_test_pool.md
@@ -468,10 +468,15 @@ If an SDK uses a REST client object to perform provisioning, it must be closed a
 ```pseudo
 provision_objects_via_rest(api_key, channel_name, operations):
   # operations: a single operation object, or an array of operation objects (batch)
-  POST https://sandbox.realtime.ably-nonprod.net/channels/{encode_uri_component(channel_name)}/object
+  response = POST https://sandbox.realtime.ably-nonprod.net/channels/{encode_uri_component(channel_name)}/object
     WITH Authorization: Basic {base64(api_key)}
     WITH Content-Type: application/json
     WITH body: operations
+  # Response contract: the body is a single result object, or a JSON array of result objects
+  # (one per batch entry); each result carries an `objectIds` string array naming the objects
+  # the operation created or updated. The helper returns them flattened, in request order, so
+  # derived tests can target follow-up operations by `objectId`.
+  RETURN [objectId FOR result IN as_list(parse_json(response.body)) FOR objectId IN result.objectIds]
 ```
 
 Operation shapes (target by `objectId` or `path`; an optional `id` on any operation is an idempotency key):

--- a/uts/objects/helpers/standard_test_pool.md
+++ b/uts/objects/helpers/standard_test_pool.md
@@ -360,6 +360,11 @@ setup_synced_channel(channel_name):
         FOR i IN 0..msg.state.length - 1:
           serials.append(ack_serial(msg.msgSerial, i))
         mock_ws.send_to_client(build_ack_message(msg.msgSerial, serials))
+      ELSE IF msg.action == DETACH:
+        mock_ws.send_to_client(ProtocolMessage(
+          action: DETACHED,
+          channel: msg.channel
+        ))
     }
   )
   install_mock(mock_ws)
@@ -401,6 +406,11 @@ setup_synced_channel_no_ack(channel_name):
         ))
         mock_ws.send_to_client(build_object_sync_message(
           msg.channel, "sync1:", STANDARD_POOL_OBJECTS
+        ))
+      ELSE IF msg.action == DETACH:
+        mock_ws.send_to_client(ProtocolMessage(
+          action: DETACHED,
+          channel: msg.channel
         ))
     }
   )

--- a/uts/objects/integration/objects_gc_test.md
+++ b/uts/objects/integration/objects_gc_test.md
@@ -88,7 +88,7 @@ root = AWAIT channel.object.get()
 ```pseudo
 // Create a counter
 AWAIT root.set("counter", LiveCounter.create(42))
-poll_until(root.get("counter").value() == 42, timeout: 10s)
+poll_until(root.get("counter").value() == 42)
 
 counter_id = root.get("counter").instance().id
 
@@ -96,11 +96,11 @@ counter_id = root.get("counter").instance().id
 AWAIT root.remove("counter")
 
 // RTLM5d2h: tombstoned entries read back as undefined/null
-poll_until(root.get("counter").value() == null, timeout: 10s)
+poll_until(root.get("counter").value() == null)
 
 // Create a new counter at the same key
 AWAIT root.set("counter", LiveCounter.create(99))
-poll_until(root.get("counter").value() == 99, timeout: 10s)
+poll_until(root.get("counter").value() == 99)
 ```
 
 ### Assertions
@@ -143,16 +143,16 @@ root = AWAIT channel.object.get()
 ```pseudo
 // Set then remove a key
 AWAIT root.set("ephemeral", "temporary")
-poll_until(root.get("ephemeral").value() == "temporary", timeout: 10s)
+poll_until(root.get("ephemeral").value() == "temporary")
 
 AWAIT root.remove("ephemeral")
 
 // RTLM5d2h: tombstoned entries read back as undefined/null
-poll_until(root.get("ephemeral").value() == null, timeout: 10s)
+poll_until(root.get("ephemeral").value() == null)
 
 // Set the same key again
 AWAIT root.set("ephemeral", "revived")
-poll_until(root.get("ephemeral").value() == "revived", timeout: 10s)
+poll_until(root.get("ephemeral").value() == "revived")
 ```
 
 ### Assertions

--- a/uts/objects/integration/objects_lifecycle_test.md
+++ b/uts/objects/integration/objects_lifecycle_test.md
@@ -78,7 +78,7 @@ AWAIT root_a.set("greeting", "hello")
 // Client B subscribes and waits for the update
 events_b = []
 root_b.subscribe((event) => events_b.append(event))
-poll_until(root_b.get("greeting").value() == "hello", timeout: 10s)
+poll_until(root_b.get("greeting").value() == "hello")
 ```
 
 ### Assertions
@@ -124,7 +124,7 @@ root_b = AWAIT channel_b.object.get()
 ### Test Steps
 ```pseudo
 AWAIT root_a.set("my_counter", LiveCounter.create(42))
-poll_until(root_b.get("my_counter").value() == 42, timeout: 10s)
+poll_until(root_b.get("my_counter").value() == 42)
 ```
 
 ### Assertions
@@ -172,11 +172,11 @@ root_b = AWAIT channel_b.object.get()
 ```pseudo
 // Create a counter first
 AWAIT root_a.set("hits", LiveCounter.create(0))
-poll_until(root_b.get("hits").value() == 0, timeout: 10s)
+poll_until(root_b.get("hits").value() == 0)
 
 // Increment it
 AWAIT root_a.get("hits").increment(10)
-poll_until(root_b.get("hits").value() == 10, timeout: 10s)
+poll_until(root_b.get("hits").value() == 10)
 ```
 
 ### Assertions
@@ -226,7 +226,7 @@ AWAIT root_a.set("settings", LiveMap.create({
   "theme": "dark",
   "fontSize": 14
 }))
-poll_until(root_b.get("settings").get("theme").value() == "dark", timeout: 10s)
+poll_until(root_b.get("settings").get("theme").value() == "dark")
 ```
 
 ### Assertions

--- a/uts/objects/integration/objects_sync_test.md
+++ b/uts/objects/integration/objects_sync_test.md
@@ -110,7 +110,7 @@ AWAIT root_a.set("key1", "value1")
 
 // Client B attaches and syncs — should see the data
 root_b = AWAIT channel_b.object.get()
-poll_until(root_b.get("key1").value() == "value1", timeout: 10s)
+poll_until(root_b.get("key1").value() == "value1")
 ```
 
 ### Assertions
@@ -157,7 +157,7 @@ AWAIT channel.attach()
 
 // Re-sync should restore data
 root = AWAIT channel.object.get()
-poll_until(root.get("before_detach").value() == "hello", timeout: 10s)
+poll_until(root.get("before_detach").value() == "hello")
 ```
 
 ### Assertions

--- a/uts/objects/integration/proxy/objects_faults.md
+++ b/uts/objects/integration/proxy/objects_faults.md
@@ -326,7 +326,8 @@ pending mutation must fail with error 92008 (RTO20e1).
 > Note: the mutation must be in flight *before* the channel fails. A mutation issued on a
 > channel already in DETACHED/FAILED/SUSPENDED fails the RTO26b write precondition with 90001
 > and never reaches publishAndApply — that is different behaviour, not this test. The unit-tier
-> test `objects/unit/RTO20e1/fails-on-channel-failed-0` uses the same sequence.
+> test `objects/unit/RTO20e1/fails-on-channel-failed-0` uses the same ERROR-based sequence
+> against a mock transport.
 
 ### Setup
 

--- a/uts/objects/integration/proxy/objects_faults.md
+++ b/uts/objects/integration/proxy/objects_faults.md
@@ -198,7 +198,7 @@ AWAIT_STATE client_b.connection.state == CONNECTED
 
 root_b = AWAIT channel_b.object.get()
   WITH timeout: 15 seconds
-poll_until(root_b.get("key1").value() == "initial", timeout: 10s)
+poll_until_success(root_b.get("key1").value() == "initial")
 
 // Disconnect client B
 session.trigger_action({ type: "disconnect" })
@@ -214,7 +214,7 @@ AWAIT_STATE client_b.connection.state == CONNECTED
 
 root_b = AWAIT channel_b.object.get()
   WITH timeout: 15 seconds
-poll_until(root_b.get("key1").value() == "updated_during_disconnect", timeout: 15s)
+poll_until_success(root_b.get("key1").value() == "updated_during_disconnect", timeout: 15s)
 ```
 
 ### Assertions
@@ -297,7 +297,7 @@ AWAIT_STATE channel.state == ChannelState.attached
 // Re-sync should restore data
 root = AWAIT channel.object.get()
   WITH timeout: 15 seconds
-poll_until(root.get("before_detach").value() == "hello", timeout: 15s)
+poll_until_success(root.get("before_detach").value() == "hello", timeout: 15s)
 ```
 
 ### Assertions
@@ -488,7 +488,7 @@ root_b = AWAIT channel_b.object.get()
   WITH timeout: 30 seconds
 
 // The mutation from A should be visible (either in sync data or buffered OBJECT)
-poll_until(root_b.get("existing").value() == "after", timeout: 15s)
+poll_until_success(root_b.get("existing").value() == "after", timeout: 15s)
 ```
 
 ### Assertions

--- a/uts/objects/unit/internal_live_counter_api.md
+++ b/uts/objects/unit/internal_live_counter_api.md
@@ -233,12 +233,17 @@ ASSERT updates[0].message.operation.counterInc.number == 7
 
 **Spec requirement:** If amount is null, not Number, not finite, or NaN, throw 40003.
 
+The `null` row applies only where `null` is passable and distinguishable from an omitted
+argument (e.g. a boxed `Integer` in Java). In SDKs whose signature makes null equivalent to
+"omitted" (e.g. `increment(amount?: number)` in JavaScript, where a nullish amount takes the
+default of 1), the row is not applicable — see the pseudocode conventions in `uts/README.md`.
+
 ### Setup
 ```pseudo
 { client, channel, root, mock_ws } = AWAIT setup_synced_channel("test")
 
 invalid_amounts = [
-  { value: null,        label: "null" },
+  { value: null,        label: "null" },  # language-applicability: see note above
   { value: NaN,         label: "NaN" },
   { value: Infinity,    label: "Infinity" },
   { value: -Infinity,   label: "-Infinity" },

--- a/uts/objects/unit/public_object_message.md
+++ b/uts/objects/unit/public_object_message.md
@@ -371,7 +371,7 @@ Tests that when the source ObjectOperation has a `mapCreate` field, the PublicAP
 source_operation = {
   action: "MAP_CREATE",
   objectId: "map:new@2000",
-  mapCreate: { semantics: "lww", entries: { "key1": { data: { string: "val1" } } } }
+  mapCreate: { semantics: "LWW", entries: { "key1": { data: { string: "val1" } } } }
 }
 ```
 
@@ -385,7 +385,7 @@ public_op = PublicObjectOperation.fromObjectOperation(source_operation)
 ASSERT public_op.action == "MAP_CREATE"
 ASSERT public_op.objectId == "map:new@2000"
 ASSERT public_op.mapCreate IS NOT null
-ASSERT public_op.mapCreate.semantics == "lww"
+ASSERT public_op.mapCreate.semantics == "LWW"
 ASSERT public_op.mapCreate.entries["key1"].data.string == "val1"
 ASSERT public_op.counterCreate == null
 ```
@@ -404,14 +404,14 @@ Tests that when the source ObjectOperation has `mapCreateWithObjectId` but not `
 
 ### Setup
 ```pseudo
-derived_map_create = { semantics: "lww", entries: { "x": { data: { number: 10 } } } }
+derived_map_create = { semantics: "LWW", entries: { "x": { data: { number: 10 } } } }
 
 source_operation = {
   action: "MAP_CREATE",
   objectId: "map:derived@3000",
   mapCreateWithObjectId: {
     objectId: "map:derived@3000",
-    semantics: "lww",
+    semantics: "LWW",
     entries: { "x": { data: { number: 10 } } },
     derivedFrom: derived_map_create  // retained MapCreate per RTLMV4j5 (local-only; not a wire field name)
   }
@@ -428,7 +428,7 @@ public_op = PublicObjectOperation.fromObjectOperation(source_operation)
 ASSERT public_op.action == "MAP_CREATE"
 ASSERT public_op.objectId == "map:derived@3000"
 ASSERT public_op.mapCreate IS NOT null
-ASSERT public_op.mapCreate.semantics == "lww"
+ASSERT public_op.mapCreate.semantics == "LWW"
 ASSERT public_op.mapCreate.entries["x"].data.number == 10
 ASSERT public_op.counterCreate == null
 ```

--- a/uts/objects/unit/public_object_message.md
+++ b/uts/objects/unit/public_object_message.md
@@ -371,7 +371,7 @@ Tests that when the source ObjectOperation has a `mapCreate` field, the PublicAP
 source_operation = {
   action: "MAP_CREATE",
   objectId: "map:new@2000",
-  mapCreate: { semantics: "LWW", entries: { "key1": { data: { string: "val1" } } } }
+  mapCreate: { semantics: "lww", entries: { "key1": { data: { string: "val1" } } } }
 }
 ```
 
@@ -385,7 +385,7 @@ public_op = PublicObjectOperation.fromObjectOperation(source_operation)
 ASSERT public_op.action == "MAP_CREATE"
 ASSERT public_op.objectId == "map:new@2000"
 ASSERT public_op.mapCreate IS NOT null
-ASSERT public_op.mapCreate.semantics == "LWW"
+ASSERT public_op.mapCreate.semantics == "lww"
 ASSERT public_op.mapCreate.entries["key1"].data.string == "val1"
 ASSERT public_op.counterCreate == null
 ```
@@ -404,14 +404,14 @@ Tests that when the source ObjectOperation has `mapCreateWithObjectId` but not `
 
 ### Setup
 ```pseudo
-derived_map_create = { semantics: "LWW", entries: { "x": { data: { number: 10 } } } }
+derived_map_create = { semantics: "lww", entries: { "x": { data: { number: 10 } } } }
 
 source_operation = {
   action: "MAP_CREATE",
   objectId: "map:derived@3000",
   mapCreateWithObjectId: {
     objectId: "map:derived@3000",
-    semantics: "LWW",
+    semantics: "lww",
     entries: { "x": { data: { number: 10 } } },
     derivedFrom: derived_map_create  // retained MapCreate per RTLMV4j5 (local-only; not a wire field name)
   }
@@ -428,7 +428,7 @@ public_op = PublicObjectOperation.fromObjectOperation(source_operation)
 ASSERT public_op.action == "MAP_CREATE"
 ASSERT public_op.objectId == "map:derived@3000"
 ASSERT public_op.mapCreate IS NOT null
-ASSERT public_op.mapCreate.semantics == "LWW"
+ASSERT public_op.mapCreate.semantics == "lww"
 ASSERT public_op.mapCreate.entries["x"].data.number == 10
 ASSERT public_op.counterCreate == null
 ```

--- a/uts/objects/unit/realtime_object.md
+++ b/uts/objects/unit/realtime_object.md
@@ -197,8 +197,6 @@ ASSERT root.path == []
 | RTO15e1 | action set to OBJECT |
 | RTO15e2 | channel set to channel name |
 | RTO15e3 | state set to encoded ObjectMessages |
-| RTO15h | Returns PublishResult from ACK |
-
 ### Setup
 ```pseudo
 captured_messages = []
@@ -224,14 +222,15 @@ mock_ws = MockWebSocket(
 install_mock(mock_ws)
 client = Realtime(options: { key: "fake:key" })
 channel = client.channels.get("test", { modes: ["OBJECT_SUBSCRIBE", "OBJECT_PUBLISH"] })
-AWAIT channel.object.get()
+root = AWAIT channel.object.get()
 ```
 
 ### Test Steps
 ```pseudo
-result = AWAIT channel.object.publish([
-  build_counter_inc("counter:score@1000", 5, null, null)
-])
+# Drive the internal publish (RTO15) through a public mutation — RTO15 is an internal
+# function; its PublishResult is consumed internally by RTO20 (apply-on-ACK), which the
+# neighbouring RTO20 tests cover. Only the observable wire behaviour is asserted here.
+AWAIT root.get("score").increment(5)
 ```
 
 ### Assertions
@@ -240,7 +239,6 @@ ASSERT captured_messages.length == 1
 ASSERT captured_messages[0].action == OBJECT
 ASSERT captured_messages[0].channel == "test"
 ASSERT captured_messages[0].state.length == 1
-ASSERT result.serials == ["serial-0"]
 ```
 
 ---
@@ -406,6 +404,11 @@ ASSERT root.get("score").value() == 110
 
 **Spec requirement:** If channel enters DETACHED/SUSPENDED/FAILED while waiting, fail with 92008.
 
+The channel is detached **client-side** while the operation waits for SYNCED — an unsolicited
+server DETACHED would trigger an immediate re-attach (RTL13a) in a compliant SDK, so the channel
+would never observably stay DETACHED. A solicited `channel.detach()` does not trigger RTL13a; the
+shared mock answers the outbound DETACH with DETACHED.
+
 ### Setup
 ```pseudo
 { client, channel, root, mock_ws } = AWAIT setup_synced_channel("test")
@@ -420,9 +423,51 @@ mock_ws.send_to_client(ProtocolMessage(
 
 inc_future = root.get("score").increment(10)
 
+# The publish and its ACK complete against the mock; publishAndApply parks in the
+# RTO20e wait for SYNCED. A client-side detach then moves the channel to DETACHED.
+AWAIT channel.detach()
+
+AWAIT inc_future FAILS WITH error
+```
+
+### Assertions
+```pseudo
+ASSERT error.code == 92008
+```
+
+---
+
+## RTO20e1 - publishAndApply fails when channel enters FAILED during sync wait
+
+**Test ID**: `objects/unit/RTO20e1/fails-on-channel-failed-0`
+
+**Spec requirement:** If channel enters DETACHED/SUSPENDED/FAILED while waiting, fail with 92008.
+
+An injected channel ERROR puts the channel into FAILED while the operation waits for SYNCED —
+the same sequence as the ERROR-based proxy-tier test
+(`objects/proxy/RTO20e/publish-fails-on-channel-failed-0`). Together with the DETACHED test above
+this covers the reachable channel states of the RTO20e1 clause; SUSPENDED is a connection-level
+state and is out of scope for a channel-level unit mock.
+
+### Setup
+```pseudo
+{ client, channel, root, mock_ws } = AWAIT setup_synced_channel("test")
+```
+
+### Test Steps
+```pseudo
 mock_ws.send_to_client(ProtocolMessage(
-  action: DETACHED, channel: "test",
-  error: { code: 90000, statusCode: 400, message: "Channel detached" }
+  action: ATTACHED, channel: "test", channelSerial: "sync2:cursor",
+  flags: HAS_OBJECTS
+))
+
+inc_future = root.get("score").increment(10)
+
+# The publish and its ACK complete against the mock; publishAndApply parks in the
+# RTO20e wait for SYNCED. Then the channel ERROR moves the channel to FAILED.
+mock_ws.send_to_client(ProtocolMessage(
+  action: ERROR, channel: "test",
+  error: { code: 90000, statusCode: 400, message: "Channel failed" }
 ))
 
 AWAIT inc_future FAILS WITH error
@@ -707,8 +752,12 @@ ASSERT error.statusCode == 400
 | RTO25b | If channel is DETACHED or FAILED, throw ErrorInfo with statusCode 400 and code 90001 |
 
 Tests that an access method (`keys()`) on a DETACHED channel throws 90001. The `root` PathObject is obtained
-while the channel is ATTACHED (with OBJECT_SUBSCRIBE granted); the channel is then detached, and the subsequent
-read trips the RTO25b state precondition. (Contrast `get()`, which re-attaches per RTO23e.)
+while the channel is ATTACHED (with OBJECT_SUBSCRIBE granted); the channel is then detached **client-side**,
+and the subsequent read trips the RTO25b state precondition. (Contrast `get()`, which re-attaches per RTO23e.)
+
+A client-side `channel.detach()` is used rather than injecting a server DETACHED, because an unsolicited
+DETACHED triggers an immediate re-attach (RTL13a) in a compliant SDK — the channel never observably stays
+DETACHED. The shared mock answers the outbound DETACH with DETACHED.
 
 ### Setup
 ```pseudo
@@ -717,11 +766,8 @@ read trips the RTO25b state precondition. (Contrast `get()`, which re-attaches p
 
 ### Test Steps
 ```pseudo
-// Detach the channel after sync
-mock_ws.send_to_client(ProtocolMessage(
-  action: DETACHED, channel: "test",
-  error: { code: 90000, statusCode: 400, message: "Channel detached" }
-))
+// Detach the channel client-side after sync
+AWAIT channel.detach()
 AWAIT_STATE channel.state == DETACHED
 
 root.keys() FAILS WITH error
@@ -827,7 +873,10 @@ ASSERT error.statusCode == 400
 |------|-------------|
 | RTO26b | If channel is DETACHED, FAILED, or SUSPENDED, throw ErrorInfo with statusCode 400 and code 90001 |
 
-Tests that a write operation on a DETACHED channel throws 90001.
+Tests that a write operation on a DETACHED channel throws 90001. The channel is detached
+**client-side** — an unsolicited server DETACHED triggers an immediate re-attach (RTL13a) in a
+compliant SDK, so the channel never observably stays DETACHED. The shared mock answers the
+outbound DETACH with DETACHED.
 
 ### Setup
 ```pseudo
@@ -836,11 +885,8 @@ Tests that a write operation on a DETACHED channel throws 90001.
 
 ### Test Steps
 ```pseudo
-// Detach the channel after sync
-mock_ws.send_to_client(ProtocolMessage(
-  action: DETACHED, channel: "test",
-  error: { code: 90000, statusCode: 400, message: "Channel detached" }
-))
+// Detach the channel client-side after sync
+AWAIT channel.detach()
 AWAIT_STATE channel.state == DETACHED
 
 AWAIT root.set("name", "Bob") FAILS WITH error
@@ -999,7 +1045,7 @@ deep_events = []
 
 // Subscribe at root with depth 1 — per RTO24c2b this covers ONLY root's own path ([]),
 // NOT its children (a child like ["score"] is relativeDepth 1-0+1 = 2 > 1).
-root.subscribe({ depth: 1 }, (event) => shallow_events.append(event))
+root.subscribe((event) => shallow_events.append(event), { depth: 1 })
 
 // Subscribe at root with no depth limit — covers everything
 root.subscribe((event) => deep_events.append(event))

--- a/uts/objects/unit/realtime_object.md
+++ b/uts/objects/unit/realtime_object.md
@@ -239,6 +239,10 @@ ASSERT captured_messages.length == 1
 ASSERT captured_messages[0].action == OBJECT
 ASSERT captured_messages[0].channel == "test"
 ASSERT captured_messages[0].state.length == 1
+# RTO15e3 - the state entry is the encoded ObjectMessage for the driven mutation
+ASSERT captured_messages[0].state[0].operation.action == COUNTER_INC
+ASSERT captured_messages[0].state[0].operation.objectId == "counter:score@1000"
+ASSERT captured_messages[0].state[0].operation.counterInc.number == 5
 ```
 
 ---
@@ -424,7 +428,10 @@ mock_ws.send_to_client(ProtocolMessage(
 inc_future = root.get("score").increment(10)
 
 # The publish and its ACK complete against the mock; publishAndApply parks in the
-# RTO20e wait for SYNCED. A client-side detach then moves the channel to DETACHED.
+# RTO20e wait for SYNCED
+ASSERT inc_future IS NOT complete
+
+# A client-side detach then moves the channel to DETACHED
 AWAIT channel.detach()
 
 AWAIT inc_future FAILS WITH error
@@ -464,7 +471,10 @@ mock_ws.send_to_client(ProtocolMessage(
 inc_future = root.get("score").increment(10)
 
 # The publish and its ACK complete against the mock; publishAndApply parks in the
-# RTO20e wait for SYNCED. Then the channel ERROR moves the channel to FAILED.
+# RTO20e wait for SYNCED
+ASSERT inc_future IS NOT complete
+
+# Then the channel ERROR moves the channel to FAILED
 mock_ws.send_to_client(ProtocolMessage(
   action: ERROR, channel: "test",
   error: { code: 90000, statusCode: 400, message: "Channel failed" }

--- a/uts/objects/unit/realtime_object.md
+++ b/uts/objects/unit/realtime_object.md
@@ -1110,8 +1110,9 @@ ASSERT deep_events.length >= 2
 enable_fake_timers()
 { client, channel, root, mock_ws } = AWAIT setup_synced_channel("test")
 
+// Tombstone stamped "now": only the ADVANCE_TIME below makes it GC-eligible
 mock_ws.send_to_client(build_object_message("test", [
-  build_object_delete("counter:score@1000", "99", "site1", 1000)
+  build_object_delete("counter:score@1000", "99", "site1", now())
 ]))
 ```
 
@@ -1417,8 +1418,11 @@ client = Realtime(options: { key: "fake:key" })
 channel = client.channels.get("test", { modes: ["OBJECT_SUBSCRIBE", "OBJECT_PUBLISH"] })
 root = AWAIT channel.object.get()
 
+// Tombstone stamped "now": after ADVANCE_TIME(6000) it is eligible under the
+// 5000ms server-provided grace but NOT under the 24h default, so this test fails
+// if the implementation ignores ConnectionDetails.objectsGCGracePeriod
 mock_ws.send_to_client(build_object_message("test", [
-  build_object_delete("counter:score@1000", "99", "site1", 1000)
+  build_object_delete("counter:score@1000", "99", "site1", now())
 ]))
 ```
 

--- a/uts/objects/unit/value_types.md
+++ b/uts/objects/unit/value_types.md
@@ -371,6 +371,11 @@ ASSERT error.code == 40003
 
 **Spec requirement:** If any key is not String, throw 40003 (RTLMV4b).
 
+This test applies only to languages where a non-string map key can be constructed. In
+JavaScript/TypeScript object keys are always coerced to strings (`{ 123: "value" }` is
+`{ "123": "value" }`), so the invalid input cannot reach the validation — the test is not
+applicable there. See the pseudocode conventions in `uts/README.md`.
+
 ### Test Steps
 ```pseudo
 vt = LiveMap.create({ 123: "value" })

--- a/uts/realtime/integration/channel_history_test.md
+++ b/uts/realtime/integration/channel_history_test.md
@@ -87,7 +87,7 @@ AWAIT pub_channel.publish(name: "event3", data: "data3")
 history = poll_until(
   condition: FUNCTION() =>
     result = AWAIT sub_channel.history()
-    RETURN result.items.length == 3,
+    RETURN result IF result.items.length == 3 ELSE null,
   interval: 500ms,
   timeout: 10s
 )

--- a/uts/realtime/integration/mutable_messages_test.md
+++ b/uts/realtime/integration/mutable_messages_test.md
@@ -528,14 +528,26 @@ AWAIT channel.updateMessage(
   operation: MessageOperation(description: "second edit")
 )
 
-# Wait for propagation before HTTP-based reads
-wait_for_propagation(2 seconds)
+# The message store is eventually consistent: poll until the second update is
+# visible rather than sleeping a fixed interval before the HTTP-based reads (a
+# found message may still be a stale version). poll_until_success treats any
+# read error as "keep polling" - see the pseudocode conventions in uts/README.md.
+msg = poll_until_success(
+  condition: FUNCTION() =>
+    m = AWAIT channel.getMessage(serial)
+    IF m.action == MessageAction.MESSAGE_UPDATE AND m.data == "v3":
+      RETURN m
+    RETURN null
+)
 
-# getMessage — should return latest version
-msg = AWAIT channel.getMessage(serial)
-
-# getMessageVersions — should return version history
-versions = AWAIT channel.getMessageVersions(serial)
+# getMessageVersions — poll until the full version history is visible
+versions = poll_until_success(
+  condition: FUNCTION() =>
+    result = AWAIT channel.getMessageVersions(serial)
+    IF result.items.length >= 3:
+      RETURN result
+    RETURN null
+)
 ```
 
 ### Assertions

--- a/uts/realtime/integration/presence_lifecycle_test.md
+++ b/uts/realtime/integration/presence_lifecycle_test.md
@@ -88,10 +88,13 @@ channel_a = client_a.channels.get(channel_name)
 channel_b = client_b.channels.get(channel_name)
 AWAIT channel_b.attach()
 
-# Subscribe on client B before client A enters
-received_enters = []
-channel_b.presence.subscribe(action: ENTER, (event) => {
-  received_enters.append(event)
+# Subscribe on client B before client A enters. Members are counted by clientId from
+# both ENTER and PRESENT events: if client B's connection drops mid-test, members it
+# missed arrive via the presence re-sync as PRESENT events rather than ENTER, and an
+# ENTER-only count would undercount forever.
+entered_client_ids = SET()
+channel_b.presence.subscribe(action: [ENTER, PRESENT], (event) => {
+  entered_client_ids.add(event.clientId)
 })
 
 # Attach client A (after B is attached and subscribed)
@@ -103,9 +106,9 @@ FOR i IN 0..member_count-1:
   futures.append(channel_a.presence.enterClient("user-${i}", data: "data-${i}"))
 AWAIT_ALL futures
 
-# Wait for client B to receive all ENTER events
+# Wait for client B to observe all members entering
 poll_until(
-  condition: FUNCTION() => received_enters.length >= member_count,
+  condition: FUNCTION() => entered_client_ids.size >= member_count,
   interval: 200ms,
   timeout: 15s
 )
@@ -116,8 +119,8 @@ members = AWAIT channel_b.presence.get()
 
 ### Assertions
 ```pseudo
-# Client B received all ENTER events via subscribe
-ASSERT received_enters.length == member_count
+# Client B observed every member entering via subscribe
+ASSERT entered_client_ids.size == member_count
 
 # All members present via get()
 ASSERT members.length == member_count

--- a/uts/realtime/unit/channels/channel_detach.md
+++ b/uts/realtime/unit/channels/channel_detach.md
@@ -717,8 +717,8 @@ mock_ws.send_to_client(ProtocolMessage(
   channel: channel_name
 ))
 
-# Let the client process the inbound message (see flush_async in uts/README.md)
-flush_async()
+# Let the client process the inbound message (see process_pending_events in uts/README.md)
+process_pending_events()
 ```
 
 ### Assertions

--- a/uts/realtime/unit/channels/channel_detach.md
+++ b/uts/realtime/unit/channels/channel_detach.md
@@ -717,8 +717,8 @@ mock_ws.send_to_client(ProtocolMessage(
   channel: channel_name
 ))
 
-# Wait for client to respond
-WAIT 100ms
+# Let the client process the inbound message (see flush_async in uts/README.md)
+flush_async()
 ```
 
 ### Assertions

--- a/uts/realtime/unit/client/realtime_client.md
+++ b/uts/realtime/unit/client/realtime_client.md
@@ -319,9 +319,9 @@ client = Realtime(options: ClientOptions(
 ASSERT client.connection.state == ConnectionState.initialized
 ASSERT mock_ws.connect_attempts.length == 0
 
-# Should remain in initialized state until explicit connect: drain pending
-# async work instead of sleeping (see flush_async in uts/README.md)
-flush_async()
+# Should remain in initialized state until explicit connect: let pending async
+# work settle instead of sleeping (see process_pending_events in uts/README.md)
+process_pending_events()
 ASSERT client.connection.state == ConnectionState.initialized
 ASSERT mock_ws.connect_attempts.length == 0
 CLOSE_CLIENT(client)

--- a/uts/realtime/unit/client/realtime_client.md
+++ b/uts/realtime/unit/client/realtime_client.md
@@ -319,8 +319,9 @@ client = Realtime(options: ClientOptions(
 ASSERT client.connection.state == ConnectionState.initialized
 ASSERT mock_ws.connect_attempts.length == 0
 
-# Should remain in initialized state until explicit connect
-WAIT 100ms
+# Should remain in initialized state until explicit connect: drain pending
+# async work instead of sleeping (see flush_async in uts/README.md)
+flush_async()
 ASSERT client.connection.state == ConnectionState.initialized
 ASSERT mock_ws.connect_attempts.length == 0
 CLOSE_CLIENT(client)

--- a/uts/rest/integration/history.md
+++ b/uts/rest/integration/history.md
@@ -63,7 +63,7 @@ AWAIT channel.publish(name: "event3", data: { "key": "value" })
 history = poll_until(
   condition: FUNCTION() =>
     result = AWAIT channel.history()
-    RETURN result.items.length == 3,
+    RETURN result IF result.items.length == 3 ELSE null,
   interval: 500ms,
   timeout: 10s
 )

--- a/uts/rest/integration/mutable_messages.md
+++ b/uts/rest/integration/mutable_messages.md
@@ -39,6 +39,7 @@ AFTER ALL TESTS:
 - All clients use `useBinaryProtocol: PROTOCOL == "msgpack"` (see Protocol Variants)
 - All clients use `endpoint: "nonprod:sandbox"`
 - All channel names use the `mutable:` namespace prefix — the test app setup configures the `mutable` namespace with `mutableMessages: true`, which is required for getMessage, updateMessage, deleteMessage, appendMessage, and annotations
+- The message store is eventually consistent: a just-written message (or version/annotation) may not be visible yet, and serial-scoped reads throw not-found until it is. Every store read below is therefore polled via `poll_until_success` (see the pseudocode conventions in `uts/README.md`), which treats any read error as "keep polling" rather than failure, raising the most recent one if the timeout expires.
 
 ### Annotation HTTP Body Format
 
@@ -130,8 +131,9 @@ channel = client.channels.get(channel_name)
 publish_result = AWAIT channel.publish(name: "test-event", data: "hello world")
 serial = publish_result.serials[0]
 
-# Retrieve the message by serial
-msg = AWAIT channel.getMessage(serial)
+# Retrieve the message by serial (polled: getMessage throws not-found until the
+# just-published message is visible in the eventually-consistent store)
+msg = poll_until_success(condition: FUNCTION() => AWAIT channel.getMessage(serial))
 ```
 
 ### Assertions
@@ -186,12 +188,12 @@ ASSERT update_result.versionSerial IS String
 ASSERT update_result.versionSerial.length > 0
 
 # Verify via getMessage — poll until the update is visible
-updated_msg = poll_until(
+updated_msg = poll_until_success(
   condition: FUNCTION() =>
     msg = AWAIT channel.getMessage(serial)
-    RETURN msg.action == MessageAction.MESSAGE_UPDATE,
-  interval: 500ms,
-  timeout: 10s
+    IF msg.action == MessageAction.MESSAGE_UPDATE:
+      RETURN msg
+    RETURN null
 )
 ASSERT updated_msg.name == "updated"
 ASSERT updated_msg.data == "updated-data"
@@ -239,12 +241,12 @@ ASSERT delete_result.versionSerial IS String
 ASSERT delete_result.versionSerial.length > 0
 
 # Verify via getMessage — poll until the delete is visible
-deleted_msg = poll_until(
+deleted_msg = poll_until_success(
   condition: FUNCTION() =>
     msg = AWAIT channel.getMessage(serial)
-    RETURN msg.action == MessageAction.MESSAGE_DELETE,
-  interval: 500ms,
-  timeout: 10s
+    IF msg.action == MessageAction.MESSAGE_DELETE:
+      RETURN msg
+    RETURN null
 )
 ASSERT deleted_msg.action == MessageAction.MESSAGE_DELETE
 ```
@@ -287,12 +289,12 @@ AWAIT channel.updateMessage(
 )
 
 # Poll version history until all versions appear
-versions = poll_until(
+versions = poll_until_success(
   condition: FUNCTION() =>
     result = AWAIT channel.getMessageVersions(serial)
-    RETURN result.items.length >= 3,
-  interval: 500ms,
-  timeout: 10s
+    IF result.items.length >= 3:
+      RETURN result
+    RETURN null
 )
 ```
 
@@ -386,12 +388,12 @@ AWAIT channel.annotations.publish(serial, Annotation(
 ))
 
 # Verify annotation exists — poll until it appears
-annotations = poll_until(
+annotations = poll_until_success(
   condition: FUNCTION() =>
     result = AWAIT channel.annotations.get(serial)
-    RETURN result.items.length >= 1,
-  interval: 500ms,
-  timeout: 10s
+    IF result.items.length >= 1:
+      RETURN result
+    RETURN null
 )
 ASSERT annotations.items.length >= 1
 
@@ -448,12 +450,12 @@ AWAIT channel.annotations.publish(serial, Annotation(
 ))
 
 # Retrieve annotations — poll until both appear
-result = poll_until(
+result = poll_until_success(
   condition: FUNCTION() =>
     r = AWAIT channel.annotations.get(serial)
-    RETURN r.items.length >= 2,
-  interval: 500ms,
-  timeout: 10s
+    IF r.items.length >= 2:
+      RETURN r
+    RETURN null
 )
 ```
 

--- a/uts/rest/integration/presence.md
+++ b/uts/rest/integration/presence.md
@@ -245,7 +245,7 @@ rest_channel = client.channels.get(channel_name)
 history = poll_until(
   condition: FUNCTION() =>
     result = AWAIT rest_channel.presence.history()
-    RETURN result.items.length >= 3,
+    RETURN result IF result.items.length >= 3 ELSE null,
   interval: 500ms,
   timeout: 10s
 )
@@ -514,7 +514,7 @@ rest_channel = client.channels.get(channel_name)
 history = poll_until(
   condition: FUNCTION() =>
     result = AWAIT rest_channel.presence.history()
-    RETURN result.items.length >= 1,
+    RETURN result IF result.items.length >= 1 ELSE null,
   interval: 500ms,
   timeout: 10s
 )

--- a/uts/rest/integration/publish.md
+++ b/uts/rest/integration/publish.md
@@ -142,7 +142,7 @@ FOR i IN 1..3:
 history = poll_until(
   condition: FUNCTION() =>
     result = AWAIT channel.history()
-    RETURN result.items.length > 0,
+    RETURN result IF result.items.length > 0 ELSE null,
   interval: 500ms,
   timeout: 10s
 )

--- a/uts/rest/unit/auth/authorize.md
+++ b/uts/rest/unit/auth/authorize.md
@@ -127,14 +127,14 @@ mock_auth_callback = (params) => {
   callback_invocations.append(params)
   RETURN TokenDetails(
     token: "token-" + str(callback_invocations.length),
-    expires: now() + 1000  # Very short expiry for testing
+    expires: now() + 3600000
   )
 }
 
 mock_http = MockHttpClient(
   onConnectionAttempt: (conn) => conn.respond_with_success(),
   onRequest: (req) => {
-    req.respond_with(200, { "channelId": "test", "status": { "isActive": true } })
+    req.respond_with(200, [])
   }
 )
 install_mock(mock_http)
@@ -149,15 +149,16 @@ AWAIT client.auth.authorize(
   tokenParams: TokenParams(clientId: "saved-client", ttl: 3600000)
 )
 
-# Wait for token to expire
-WAIT 1500 milliseconds
-
-# Force re-auth via request - should reuse saved params
-AWAIT client.channels.get("test").status()
+# Second authorize without explicit params — RSA10a: authorize() always requests
+# a new token, so the callback runs again and must receive the saved params.
+# (Deterministic: no short-expiry token or real-time wait needed.)
+AWAIT client.auth.authorize()
 ```
 
 ### Assertions
 ```pseudo
+ASSERT callback_invocations.length == 2
+
 # Second callback should have received the saved params
 ASSERT callback_invocations[1].clientId == "saved-client"
 ASSERT callback_invocations[1].ttl == 3600000

--- a/uts/rest/unit/fallback.md
+++ b/uts/rest/unit/fallback.md
@@ -497,6 +497,7 @@ Tests that cached fallback host is cleared after `fallbackRetryTimeout`.
 
 ### Setup
 ```pseudo
+enable_fake_timers()
 mock_http = MockHttpClient()
 mock_http.queue_response_for_host("main.realtime.ably.net", 500, { "error": {} })
 mock_http.queue_response_for_host("main.a.fallback.ably-realtime.com", 200, { "time": 1000 })
@@ -514,8 +515,8 @@ client = Rest(options: ClientOptions(
 # First request triggers fallback
 AWAIT client.time()
 
-# Wait for timeout to expire
-WAIT 150 milliseconds
+# Advance fake time past fallbackRetryTimeout
+ADVANCE_TIME(150)
 
 # Next request should try primary again
 AWAIT client.time()
@@ -541,6 +542,7 @@ Tests that a request that completes successfully against a fallback *after* `fal
 
 ### Setup
 ```pseudo
+enable_fake_timers()
 mock_http = MockHttpClient()
 
 # Request handler: primary fails on first attempt, all others succeed.
@@ -578,8 +580,8 @@ AWAIT client.time()
 # Request 3: goes to cached fallback, but we hold the response
 request_future = client.time()   # starts but does not complete
 
-# Advance time past fallbackRetryTimeout so the cache expires
-WAIT 150 milliseconds
+# Advance fake time past fallbackRetryTimeout so the cache expires
+ADVANCE_TIME(150)
 
 # Request 4: cache expired → should try primary again
 AWAIT client.time()


### PR DESCRIPTION
- Fixes https://ably.atlassian.net/browse/AIT-1141

## Summary

Spec-side corrections produced by a comprehensive audit that reconciled ably-js LiveObjects against the objects spec (`objects-features.md` + `uts/objects`), treating the reference implementation as the source of truth for behaviours that have already shipped. Every UTS unit test body was cross-checked against its derived implementation; the changes below fix spec tests that were unrunnable for a compliant SDK, assertions that contradicted the shipped public API, and pseudocode gaps that forced SDKs to document avoidable "deviations".

Companion implementation PR: ably/ably-js#2263 (source fixes + derived tests, kept in lock-step with the test IDs and bodies changed here).

## Changes

### 1. Unsolicited-server-DETACHED tests were unrunnable — switched to client-side detach

`RTO25b/access-throws-detached-0`, `RTO26b/write-throws-detached-0` and the RTO20e1 test injected an unsolicited server `DETACHED` and then asserted `AWAIT_STATE channel.state == DETACHED`. A compliant SDK immediately re-attaches on an unsolicited DETACHED (RTL13a), so the DETACHED state is transient, the `AWAIT_STATE` is a race, and — since every mock answers the re-ATTACH with ATTACHED — the precondition under test evaporates. This is the same reasoning that moved the proxy tier to an ERROR-based sequence in #501, and the spec's own RTPO19b test already used the correct pattern.

All three now reach DETACHED via a client-side `AWAIT channel.detach()` (solicited detach does not trigger RTL13a), and the shared helper mocks (`setup_synced_channel`, `setup_synced_channel_no_ack`) gain the DETACH → DETACHED responder the tests rely on.

### 2. RTO20e1 now covers both reachable states

The single DETACHED-injection test is replaced by a pair:

- `objects/unit/RTO20e1/fails-on-channel-detached-0` — client-side detach while the operation waits for SYNCED.
- `objects/unit/RTO20e1/fails-on-channel-failed-0` (new) — channel ERROR → FAILED, the same sequence as the proxy-tier test.

SUSPENDED is a connection-level state and is noted as out of scope for a channel-level unit mock.

### 3. RTO15 test asserts observable behaviour only

The test obtained `result = AWAIT channel.object.publish([...])` and asserted `result.serials` — but RTO15 defines an **internal** function, and the realtime `channel.object` exposes no public `publish`. The test now drives the publish through a public mutation and asserts the outbound OBJECT ProtocolMessage shape; the `PublishResult.serials` contract is observed through its only consumer, the neighbouring RTO20 apply-on-ACK tests. The `RTO15h` clause itself is unchanged.

### 4. Public map semantics asserted as `"lww"`

The shipped public type is lowercase (`ObjectsMapSemantics = 'lww' | 'unknown'` in ably-js); asserting `"LWW"` could never match the public API. Five assertions in `public_object_message.md` updated. *Reviewer note: please confirm ably-java's public rendering agrees — if it shipped uppercase, this becomes a cross-SDK reconciliation instead.*

### 5. Pseudocode conventions and language-applicability notes

- `uts/README.md` gains a conventions section: `== null` means the language-appropriate absent value (`undefined` in JS); member access written as a call (`instance.id()`) is satisfied by a property where the features spec defines one (RTINS3); inputs that cannot be constructed in a language (non-string map keys in JS, `null` where it is indistinguishable from "omitted") make that test/row not applicable — sanctioned omissions rather than coverage gaps.
- The `RTLC12e1` invalid-amounts table's `null` row and the `RTLMV4b` key-type test carry explicit applicability notes referencing those conventions.

This lets SDKs retire boilerplate "deviation" records for what are really language-mapping conventions.

### 6. Small fixes

- `RTO24c1` subscribe call flipped to listener-first (`subscribe(listener, { depth: 1 })`), matching every other with-options call after the argument-order convergence.
- `objects_faults.md` unit-tier cross-reference updated to `fails-on-channel-failed-0`, the test whose ERROR-based sequence it describes.

## Verification

The derived ably-js tests for every changed body pass spec-verbatim (full UTS unit suite: 1351 passing) — see ably/ably-js#2263 for the implementation side, including the two runtime bugs the same audit surfaced (sub-16-character object-id nonces, and one malformed inbound operation discarding its siblings).

## Follow-ups (out of scope here)

- Nil operation payloads (`COUNTER_INC` without `counterInc`, `MAP_SET` without `mapSet`, `MAP_REMOVE` without `mapRemove`) are spec-silent; ably-js now warns-and-skips them consistently with RTLC7d3/RTLM15d4. Proposing explicit sub-clauses is left as a follow-up.
- `uts-liveobjects` predates `main`'s `OD2g`/`OD3g` (`json` ObjectData) clauses — a merge from `main` is recommended before further UTS reconciliation.
