### PR TITLE
[AIT-1204] Add RTLO4e10 and RTO10c1b1: the root object must never be tombstoned or GC-evicted

### DIFF
--- a/specifications/objects-features.md
+++ b/specifications/objects-features.md
@@ -230,6 +230,7 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
     - `(RTO10c1)` For each `LiveObject` in the `ObjectsPool`:
       - `(RTO10c1a)` Check if the `LiveObject` needs to release any resources, see [RTLM19](#RTLM19)
       - `(RTO10c1b)` If `LiveObject.isTombstone` is `true`, and the difference between the current time and `LiveObject.tombstonedAt` is greater than or equal to the [grace period](#RTO10b), remove the object from the `ObjectsPool` and release resources for the corresponding object entity to allow it to be garbage collected
+        - `(RTO10c1b1)` The object with ID `root` must not be removed from `ObjectsPool`, as per [RTO3b](#RTO3b). Note that the `root` object can never become tombstoned per [RTLO4e10](#RTLO4e10), so this exclusion acts as an additional safeguard for the [RTO3b](#RTO3b) invariant
 - `(RTO13)` This clause has been deleted (redundant to [RTO11f15](#RTO11f15) and [RTO12f13](#RTO12f13)) as of specification version 6.0.0.
   - `(RTO13a)` This clause has been deleted as of specification version 6.0.0.
     - `(RTO13a1)` This clause has been deleted as of specification version 6.0.0.
@@ -383,6 +384,7 @@ Objects feature enables clients to store shared data as "objects" on a channel. 
   - `(RTLO4e)` protected `tombstone` - a convenience method used to tombstone this `LiveObject`. The realtime system reserves the right to tombstone an object (i.e. mark it for deletion from the objects pool) by publishing an `OBJECT_DELETE` operation at any time if the object is orphaned (not a descendant of the root object) or remains uninitialized (no `*_CREATE` operation has been received) for an extended period. Only the realtime system may publish an `OBJECT_DELETE` operation; clients must never send it. This method describes the steps the client library must take when it needs to tombstone an object locally. Eventually, tombstoned objects will be garbage collected following the procedure described in [RTO10](#RTO10)
     - `(RTLO4e1)` Expects the following arguments:
       - `(RTLO4e1a)` `ObjectMessage`
+    - `(RTLO4e10)` If `LiveObject.objectId` is `root`, log a warning indicating that an attempt was made to tombstone the `root` object, and return a `LiveObjectUpdate` with `LiveObjectUpdate.noop` set to `true` without performing any of the subsequent steps in this clause. The `root` object must always exist in the `ObjectsPool` per [RTO3b](#RTO3b); it is never orphaned or uninitialized, so the realtime system never publishes an `OBJECT_DELETE` operation or an `ObjectState` with `tombstone` set to `true` targeting it — receiving one indicates a faulty message
     - `(RTLO4e2)` Set `LiveObject.isTombstone` to `true`
     - `(RTLO4e3)` Set `LiveObject.tombstonedAt` to the value calculated per [RTLO6](#RTLO6), using `ObjectMessage.serialTimestamp`
       - `(RTLO4e3a)` This clause has been replaced by [RTLO6a](#RTLO6a)

--- a/uts/objects/unit/internal_live_map.md
+++ b/uts/objects/unit/internal_live_map.md
@@ -584,12 +584,53 @@ ASSERT map.data == {}
 | RTLO4e6 | Set tombstone flag on the update |
 | RTLO4e7 | Set objectMessage on the update |
 
+Uses a non-root map: an `OBJECT_DELETE` targeting `root` is rejected per RTLO4e10
+(see `objects/unit/RTLO4e10/object-delete-root-noop-0`).
+
+### Setup
+```pseudo
+map = InternalLiveMap(objectId: "map:test@1000", semantics: "LWW")
+map.data = {
+  "name": { data: { string: "Alice" }, timeserial: "01", tombstone: false },
+  "age":  { data: { number: 30 },      timeserial: "01", tombstone: false }
+}
+map.siteTimeserials = { "site1": "00" }
+```
+
+### Test Steps
+```pseudo
+msg = build_object_delete("map:test@1000", "01", "site1", 1700000000000)
+update = map.applyOperation(msg, source: CHANNEL)
+```
+
+### Assertions
+```pseudo
+ASSERT map.isTombstone == true
+ASSERT map.data == {}
+ASSERT update.update == { "name": "removed", "age": "removed" }
+ASSERT update.tombstone == true
+ASSERT update.objectMessage == msg
+```
+
+---
+
+## RTLO4e10 - OBJECT_DELETE targeting root is rejected
+
+**Test ID**: `objects/unit/RTLO4e10/object-delete-root-noop-0`
+
+| Spec | Requirement |
+|------|-------------|
+| RTLO4e10 | Tombstoning root logs a warning and returns a noop update |
+| RTO3b | ObjectsPool must always contain the root object |
+
+The realtime system never publishes an `OBJECT_DELETE` targeting `root` (RTLO4e); if
+one is received it indicates a faulty message and must not tombstone the root object.
+
 ### Setup
 ```pseudo
 map = InternalLiveMap(objectId: "root", semantics: "LWW")
 map.data = {
-  "name": { data: { string: "Alice" }, timeserial: "01", tombstone: false },
-  "age":  { data: { number: 30 },      timeserial: "01", tombstone: false }
+  "name": { data: { string: "Alice" }, timeserial: "01", tombstone: false }
 }
 map.siteTimeserials = { "site1": "00" }
 ```
@@ -602,11 +643,9 @@ update = map.applyOperation(msg, source: CHANNEL)
 
 ### Assertions
 ```pseudo
-ASSERT map.isTombstone == true
-ASSERT map.data == {}
-ASSERT update.update == { "name": "removed", "age": "removed" }
-ASSERT update.tombstone == true
-ASSERT update.objectMessage == msg
+ASSERT map.isTombstone == false
+ASSERT map.data["name"].data.string == "Alice"  // data untouched
+ASSERT update.noop == true
 ```
 
 ---
@@ -775,6 +814,50 @@ ASSERT map.createOperationIsMerged == true
 | RTLO4e6 | Tombstone flag set on the update |
 | RTLO4e7 | objectMessage set on the update |
 
+Uses a non-root map: tombstoning `root` is rejected per RTLO4e10
+(see `objects/unit/RTLO4e10/replace-data-tombstone-root-noop-0`).
+
+### Setup
+```pseudo
+map = InternalLiveMap(objectId: "map:test@1000", semantics: "LWW")
+map.data = {
+  "name": { data: { string: "Alice" }, timeserial: "01", tombstone: false }
+}
+```
+
+### Test Steps
+```pseudo
+state_msg = build_object_state("map:test@1000", {"site1": "01"}, {
+  map: { semantics: "LWW", entries: {} },
+  tombstone: true
+})
+update = map.replaceData(state_msg)
+```
+
+### Assertions
+```pseudo
+ASSERT map.isTombstone == true
+ASSERT map.data == {}
+ASSERT update.update == { "name": "removed" }
+ASSERT update.tombstone == true
+ASSERT update.objectMessage == state_msg
+```
+
+---
+
+## RTLO4e10 - replaceData with tombstone flag targeting root is rejected
+
+**Test ID**: `objects/unit/RTLO4e10/replace-data-tombstone-root-noop-0`
+
+| Spec | Requirement |
+|------|-------------|
+| RTLM6f | ObjectState.tombstone true routes to LiveObject.tombstone |
+| RTLO4e10 | Tombstoning root logs a warning and returns a noop update |
+
+The sync path (RTLM6f) reaches the same `LiveObject.tombstone` method as
+OBJECT_DELETE, so an `ObjectState` with `tombstone: true` for `root` must be
+rejected the same way.
+
 ### Setup
 ```pseudo
 map = InternalLiveMap(objectId: "root", semantics: "LWW")
@@ -794,11 +877,9 @@ update = map.replaceData(state_msg)
 
 ### Assertions
 ```pseudo
-ASSERT map.isTombstone == true
-ASSERT map.data == {}
-ASSERT update.update == { "name": "removed" }
-ASSERT update.tombstone == true
-ASSERT update.objectMessage == state_msg
+ASSERT map.isTombstone == false
+ASSERT map.data["name"].data.string == "Alice"  // data untouched
+ASSERT update.noop == true
 ```
 
 ---
@@ -1300,6 +1381,9 @@ ASSERT update.objectMessage == msg
 
 Tests that when an InternalLiveMap is tombstoned (via OBJECT_DELETE), removeParentReference is called for each entry that references a LiveObject before the data is cleared.
 
+Uses a non-root map: tombstoning `root` is rejected per RTLO4e10
+(see `objects/unit/RTLO4e10/object-delete-root-noop-0`).
+
 ### Setup
 ```pseudo
 pool = ObjectsPool()
@@ -1308,20 +1392,20 @@ child_map = InternalLiveMap(objectId: "map:child@1000", semantics: "LWW")
 pool["counter:child@1000"] = child_counter
 pool["map:child@1000"] = child_map
 
-map = InternalLiveMap(objectId: "root", semantics: "LWW", pool: pool)
+map = InternalLiveMap(objectId: "map:test@1000", semantics: "LWW", pool: pool)
 map.data = {
   "counter_ref": { data: { objectId: "counter:child@1000" }, timeserial: "01", tombstone: false },
   "map_ref":     { data: { objectId: "map:child@1000" },     timeserial: "01", tombstone: false },
   "name":        { data: { string: "Alice" },                 timeserial: "01", tombstone: false }
 }
 map.siteTimeserials = { "site1": "00" }
-child_counter.parentReferences = { "root": {"counter_ref"} }
-child_map.parentReferences = { "root": {"map_ref"} }
+child_counter.parentReferences = { "map:test@1000": {"counter_ref"} }
+child_map.parentReferences = { "map:test@1000": {"map_ref"} }
 ```
 
 ### Test Steps
 ```pseudo
-msg = build_object_delete("root", "01", "site1", 1700000000000)
+msg = build_object_delete("map:test@1000", "01", "site1", 1700000000000)
 update = map.applyOperation(msg, source: CHANNEL)
 ```
 
@@ -1330,8 +1414,8 @@ update = map.applyOperation(msg, source: CHANNEL)
 ASSERT map.isTombstone == true
 ASSERT map.data == {}
 // removeParentReference was called on both children
-ASSERT "root" NOT IN child_counter.parentReferences OR "counter_ref" NOT IN child_counter.parentReferences["root"]
-ASSERT "root" NOT IN child_map.parentReferences OR "map_ref" NOT IN child_map.parentReferences["root"]
+ASSERT "map:test@1000" NOT IN child_counter.parentReferences OR "counter_ref" NOT IN child_counter.parentReferences["map:test@1000"]
+ASSERT "map:test@1000" NOT IN child_map.parentReferences OR "map_ref" NOT IN child_map.parentReferences["map:test@1000"]
 ASSERT update.update == { "counter_ref": "removed", "map_ref": "removed", "name": "removed" }
 ASSERT update.tombstone == true
 ASSERT update.objectMessage == msg

--- a/uts/objects/unit/realtime_object.md
+++ b/uts/objects/unit/realtime_object.md
@@ -1143,6 +1143,12 @@ one indicates a faulty message. It must not tombstone the root object (RTLO4e10)
 and even after the GC grace period elapses the root object must remain in the pool
 and stay functional (RTO10c1b1, safeguarding RTO3b).
 
+Note: this test verifies the composed behaviour. The RTO10c1b1 branch in isolation
+(a tombstoned root surviving the GC sweep) is deliberately not exercised: RTLO4e10
+makes that state unreachable in a conforming implementation, so the GC-side
+exclusion is defense-in-depth verified by its spec tag rather than by fabricating
+an impossible state.
+
 ### Setup
 ```pseudo
 enable_fake_timers()

--- a/uts/objects/unit/realtime_object.md
+++ b/uts/objects/unit/realtime_object.md
@@ -1128,6 +1128,52 @@ ASSERT root.get("score").value() == null
 
 ---
 
+## RTO10c1b1 - GC never removes the root object
+
+**Test ID**: `objects/unit/RTO10c1b1/gc-root-never-removed-0`
+
+| Spec | Requirement |
+|------|-------------|
+| RTLO4e10 | OBJECT_DELETE targeting root is rejected with a warning |
+| RTO10c1b1 | The root object is never removed from the pool by GC |
+| RTO3b | ObjectsPool must always contain the root object |
+
+The realtime system never publishes an `OBJECT_DELETE` targeting `root`; receiving
+one indicates a faulty message. It must not tombstone the root object (RTLO4e10),
+and even after the GC grace period elapses the root object must remain in the pool
+and stay functional (RTO10c1b1, safeguarding RTO3b).
+
+### Setup
+```pseudo
+enable_fake_timers()
+{ client, channel, root, mock_ws } = AWAIT setup_synced_channel("test")
+
+// Rogue OBJECT_DELETE targeting the root object: rejected per RTLO4e10
+mock_ws.send_to_client(build_object_message("test", [
+  build_object_delete("root", remote_serial(0), "remote", now())
+]))
+```
+
+### Test Steps
+```pseudo
+ASSERT root.get("name").value() == "Alice"  // root not tombstoned, data untouched
+
+ADVANCE_TIME(86400000 + 300000)
+
+// root must still be live: a subsequent operation still applies to the same
+// root object the client holds
+mock_ws.send_to_client(build_object_message("test", [
+  build_map_set("root", "name", { string: "Bob" }, remote_serial(1), "remote")
+]))
+```
+
+### Assertions
+```pseudo
+ASSERT root.get("name").value() == "Bob"
+```
+
+---
+
 ## RTO20 - Echo deduplication via appliedOnAckSerials
 
 **Test ID**: `objects/unit/RTO20/echo-dedup-0`


### PR DESCRIPTION
Fixes https://ably.atlassian.net/browse/AIT-1204

## Problem

Raised in the ably-js PR review: [ably/ably-js#2219 (discussion)](https://github.com/ably/ably-js/pull/2219#discussion_r3558197916) — the GC sweep deletes any tombstoned object past the grace period with no protection for the root object.

Investigating it surfaced a spec-level inconsistency:

- **RTO3b** states the `ObjectsPool` "must **always** contain" the root `InternalLiveMap`.
- **RTO5c2a** already protects root during sync cleanup.
- **RTO10c1b**, however, mandates removing *any* tombstoned object past the grace period — with no root exclusion. A spec-compliant SDK was therefore *compelled* to violate RTO3b.

And the deeper gap: nothing prevented the root object from being **tombstoned** in the first place. Per RTLO4e the realtime system only tombstones orphaned/uninitialized objects — root is by definition neither — but no client-side guard existed. If a faulty `OBJECT_DELETE` (or a tombstoned `ObjectState`) ever targeted root:

1. Root's data is cleared and **all its subscriptions are deregistered**.
2. Tombstone is a **terminal state** — no re-sync or re-attach ever resurrects it. The channel's objects are permanently dead from that moment.
3. After the grace period, GC **evicts root from the pool**; `root` cannot be re-created as a zero-value object (`"root"` is not parseable as an object id per RTO6b1), so every subsequent objects operation on the channel fails unrecoverably.

## Changes

### Feature spec (`objects-features.md`)

| Clause | Content |
|---|---|
| **RTLO4e10** (new) | `LiveObject.tombstone` must reject the root object: log a warning, return a noop `LiveObjectUpdate`, perform no state change. Placed in the shared tombstone method so one guard covers both the RTLO5 operation path and the RTLC6f/RTLM6f sync paths. |
| **RTO10c1b1** (new) | The GC sweep must never remove the root object from the `ObjectsPool` (mirrors RTO5c2a). Defense-in-depth for the RTO3b invariant — root can never become tombstoned per RTLO4e10, so this is a safeguard. |

### UTS test specs

- **`internal_live_map.md`**
  - New tests: `RTLO4e10/object-delete-root-noop-0` (operation path) and `RTLO4e10/replace-data-tombstone-root-noop-0` (sync path) — root is not tombstoned, data untouched, noop update returned.
  - The three existing tombstone-mechanics tests (`RTLO5`, `RTLM6f`, `RTLO4e9`) are repointed from `objectId: "root"` to a tombstoneable non-root map (`map:test@1000`). Their stimuli would noop under the new guard; the assertions themselves are unchanged. This also reconciles the spec with the non-root ids the ably-js derived tests already used.
- **`realtime_object.md`**
  - New channel-level test `RTO10c1b1/gc-root-never-removed-0`: a rogue `OBJECT_DELETE` targeting root leaves it untouched, and after the GC grace period elapses root remains in the pool and still applies subsequent operations.

## Severity note

Exposure requires the server to send something the protocol says it never sends (clients must never publish `OBJECT_DELETE`, and the system never targets root), so this is defensive hardening — but the blast radius is terminal and unrecoverable, and RTO5c2a already set the precedent of defending root against exactly this class of anomaly.

## SDK implementations

- ably-js: ably/ably-js#2270
- ably-java: guards implemented on `fix/liveobjects-objects-audit-op-handling` (PR to follow)
