### PR TITLE
Define message-size string accounting as UTF-8 byte length (with explicit string-length exceptions)

### DIFF
--- a/specifications/features.md
+++ b/specifications/features.md
@@ -1242,10 +1242,10 @@ The core SDK provides an API for wrapper SDKs to supply Ably with analytics info
 - `(TM3)` `fromEncoded` and `fromEncodedArray` are alternative constructors that take an (already deserialized) `Message`-like object (or array of such objects), and optionally a `channelOptions`, and return a `Message` (or array of such `Messages`) that's decoded and decrypted as specified in `RSL6`, using the cipher in the `channelOptions` if the message is encrypted, with any residual transforms (ones that the library cannot decode or decrypt) left in the `encoding` property per `RSL6b`. This is intended for users receiving messages other than from a REST or Realtime channel (for example, from a queue), to avoid them having to parse the `encoding` string themselves.
 - `(TM6)` The size of the `Message` for [TO3l8](#TO3l8) is calculated as follows:
   - `(TM6a)` The size is the sum of the sizes of the `name`, `data`, `clientId`, and `extras` properties
-  - `(TM6b)` The size of an `Object` or `Array` `data` property is its string length after being JSON-stringified
+  - `(TM6b)` The size of an `Object` or `Array` `data` property is its string length (the number of UTF-16 code units) after being JSON-stringified
   - `(TM6c)` The size of a `binary` `data` property is its size in bytes (of the actual binary, not the base64 representation, regardless of whether the binary protocol is in use)
-  - `(TM6f)` The size of a `string` `data` property is its length
-  - `(TM6d)` The size of the `extras` property is the string length of its JSON representation
+  - `(TM6f)` The size of a `string` `data` property is its UTF-8 byte length
+  - `(TM6d)` The size of the `extras` property is the string length (the number of UTF-16 code units) of its JSON representation
   - `(TM6e)` The size of a `null` or omitted property is zero
 - `(TM7)` The SDK may expose a series of functions (static factory methods on a Message or otherwise, wherever is language idiomatic; for some languages this might just be types that can be used for type assertions, etc), that take a deserialized `JsonObject`, one of the aggregated summaries for a particular annotation type (that is, a value from the `TM2q` `summary` `Dict`), and outputs a strongly-typed summary entry, for ease of use by the end user (particularly in languages where manipulating plain objects is difficult).
   - `(TM7a)` The SDK must not try to do this conversion automatically (either by parsing the annotation type or dynamically detecting the structure). This is so that, when the server adds new annotation types that the SDK does not yet know about, when we later add support for those new types to the SDK, that does not result in a a breaking API change for the SDK.
@@ -1314,8 +1314,8 @@ The core SDK provides an API for wrapper SDKs to supply Ably with analytics info
   - `(OM3a)` The size is the sum of the sizes of the `clientId`, `operation`, `object`, and `extras` properties
   - `(OM3b)` The size of the `operation` property is calculated per [OOP4](#OOP4)
   - `(OM3c)` The size of the `object` property is calculated per [OST3](#OST3)
-  - `(OM3d)` The size of the `extras` property is the string length of its JSON representation
-  - `(OM3f)` The size of the `clientId` property is its string length
+  - `(OM3d)` The size of the `extras` property is the string length (the number of UTF-16 code units) of its JSON representation
+  - `(OM3f)` The size of the `clientId` property is its UTF-8 byte length
   - `(OM3e)` The size of a `null` or omitted property is zero
 - `(OM4)` For `ObjectMessage` encoding see `ObjectData` [OD4](#OD4) encoding
 - `(OM5)` For `ObjectMessage` decoding see `ObjectData` [OD5](#OD5) decoding
@@ -1396,7 +1396,7 @@ The core SDK provides an API for wrapper SDKs to supply Ably with analytics info
   - `(MCR2b)` `entries` `Dict<String, ObjectsMapEntry>` - the map entries, indexed by key
 - `(MCR3)` The size of the `MapCreate` is calculated as follows:
   - `(MCR3a)` The size is the sum of the sizes of all map entries in `entries` property
-    - `(MCR3a1)` Includes the size of the `String` key for the map entry, calculated as its length
+    - `(MCR3a1)` Includes the size of the `String` key for the map entry, calculated as its UTF-8 byte length
     - `(MCR3a2)` Includes the size of the `ObjectsMapEntry` object for the map entry, calculated per [OME3](#OME3)
   - `(MCR3b)` The size of a `null` or omitted property is zero
 
@@ -1409,7 +1409,7 @@ The core SDK provides an API for wrapper SDKs to supply Ably with analytics info
 - `(MST3)` The size of the `MapSet` is calculated as follows:
   - `(MST3a)` The size is the sum of the sizes of the `key` and `value` properties
   - `(MST3b)` The size of the `value` property is calculated per [OD3](#OD3)
-  - `(MST3c)` The size of the `key` property is its string length
+  - `(MST3c)` The size of the `key` property is its UTF-8 byte length
   - `(MST3d)` The size of a `null` or omitted property is zero
 
 #### MapRemove
@@ -1418,7 +1418,7 @@ The core SDK provides an API for wrapper SDKs to supply Ably with analytics info
 - `(MRM2)` The attributes available in a `MapRemove` are:
   - `(MRM2a)` `key` string - the key to remove
 - `(MRM3)` The size of the `MapRemove` is calculated as follows:
-  - `(MRM3a)` The size is the string length of the `key` property
+  - `(MRM3a)` The size is the UTF-8 byte length of the `key` property
   - `(MRM3b)` The size of a `null` or omitted property is zero
 
 #### CounterCreate
@@ -1495,7 +1495,7 @@ The core SDK provides an API for wrapper SDKs to supply Ably with analytics info
   - `(OMP3c)` `clearTimeserial` string - the [serial](#OM2h) value of the last `MAP_CLEAR` operation applied to the map. If no `MAP_CLEAR` has been applied, this field is omitted
 - `(OMP4)` The size of the `ObjectsMap` is calculated as follows:
   - `(OMP4a)` The size is the sum of the sizes of all map entries in `entries` property
-    - `(OMP4a1)` Includes the size of the `String` key for the map entry, calculated as its length
+    - `(OMP4a1)` Includes the size of the `String` key for the map entry, calculated as its UTF-8 byte length
     - `(OMP4a2)` Includes the size of the `ObjectsMapEntry` object for the map entry, calculated per [OME3](#OME3)
   - `(OMP4b)` The size of a `null` or omitted property is zero
 
@@ -1537,8 +1537,8 @@ The core SDK provides an API for wrapper SDKs to supply Ably with analytics info
   - `(OD3b)` If set, the size of a `boolean` property is 1
   - `(OD3c)` If set, the size of a `bytes` property is its size in bytes (of the actual binary, not the base64 representation, regardless of whether the binary protocol is in use)
   - `(OD3d)` If set, the size of a `number` property is 8
-  - `(OD3e)` If set, the size of a `string` property is its length
-  - `(OD3g)` If set, the size of a `json` property is the byte length of its JSON-encoded string representation
+  - `(OD3e)` If set, the size of a `string` property is its UTF-8 byte length
+  - `(OD3g)` If set, the size of a `json` property is the UTF-8 byte length of its JSON-encoded string representation
   - `(OD3f)` The size of a `null` or omitted property is zero
 - `(OD4)` `ObjectData` encoding:
   - `(OD4a)` Payloads must be booleans, binary, numbers, strings, or JSON-encodable objects or arrays. Any other data type must not be permitted and result in an error with code 40013
@@ -1956,7 +1956,7 @@ The core SDK provides an API for wrapper SDKs to supply Ably with analytics info
       - `(TO3l8c)` This clause has been replaced by [TM6c](#TM6c)
       - `(TO3l8d)` This clause has been replaced by [TM6d](#TM6d)
       - `(TO3l8e)` This clause has been replaced by [TM6e](#TM6e)
-      - `(TO3l8f)` The size is defined as the sum of all message sizes being published, calculated based on [TM6](#TM6), [TP5](#TP5) and [OM3](#OM3)
+      - `(TO3l8f)` The size is defined as the sum of all message sizes being published, calculated based on [TM6](#TM6), [TP5](#TP5) and [OM3](#OM3). Unless a clause explicitly states otherwise, string sizes in message-size accounting are measured as their UTF-8 byte length (this includes the `json` `ObjectData` payload, [OD3g](#OD3g)). The only exceptions are the `extras` property ([TM6d](#TM6d)/[OM3d](#OM3d)) and an `Object` or `Array` `data` property ([TM6b](#TM6b)), whose JSON representations are instead measured by string length (the number of UTF-16 code units), matching the service's published accounting for `extras`
     - `(TO3l9)` `maxFrameSize` integer - default 524288 (512KiB). The maximum size of a single POST body or [WebSocket](https://ably.com/topic/websockets) frame. This is mostly only relevant for \`RestClient#request\` (e.g. for batch publishes), since publishes will hit the `maxMessageSize` limit before this
     - `(TO3l10)` `fallbackRetryTimeout` integer - default 600000 (10 minutes). (After a failed request to the default endpoint, followed by a successful request to a fallback endpoint), the period in milliseconds before HTTP requests are retried against the default endpoint
   - `(TO3o)` `plugins` `Dict<PluginType:Plugin>` A map between a `PluginType` and a `Plugin` object. The client library might downcast a `Plugin` to particular plugin type.


### PR DESCRIPTION
## Problem

The client-side publish-size gate (`RTO15d` for `ObjectMessage`, `TO3l8`/`maxMessageSize` for `Message`) sums per-field sizes and rejects an over-limit publish before it hits the wire. The spec told SDKs to measure string fields by their "length", but never said whether "length" means **UTF-8 bytes** or **UTF-16 code units**. For ASCII these coincide; for non-ASCII they diverge (`你` = 3 UTF-8 bytes / 1 UTF-16 code unit; `😊` = 4 UTF-8 bytes / 2 UTF-16 code units).

The spec was also **internally contradictory**:

- `OM3d` (extras): *"the string length of its JSON representation"* — reads as UTF-16 code units.
- `OD3g` (json): *"the byte length of its JSON-encoded string representation"* — explicitly bytes.
- `OM3f` / `MCR3a1` / `MST3c` / `MRM3a` / `OMP4a1` / `OD3e` / `TM6f`: bare *"length"* — undefined.

Because "length" was undefined, the SDKs **diverged**, and the same map key or `clientId` produced different gate results across SDKs. Concrete before-state (`clientId = "émile"`, keys = `"héllo👍"`, string data = `"你好"`, extras = `{"k":"你"}`):

| Field (spec point)        | Value      | cocoa (before) | java (before) | js (before) | After (all SDKs) |
|---------------------------|------------|:--------------:|:-------------:|:-----------:|:----------------:|
| `clientId` (OM3f)         | `émile`    | 6 (UTF-8)      | 6 (UTF-8)     | **5 (UTF-16)** | 6             |
| MapSet key (MST3c)        | `héllo👍`  | 10 (UTF-8)     | 10 (UTF-8)    | **7 (UTF-16)** | 10            |
| map-state key (OMP4a1)    | `héllo👍`  | **7 (UTF-16)** | **7 (UTF-16)**| **7 (UTF-16)** | 10            |
| string data (OD3e)        | `你好`     | 6 (UTF-8)      | 6 (UTF-8)     | 6 (UTF-8)   | 6                |
| extras JSON (OM3d)        | `{"k":"你"}`| 9 (UTF-16)    | 9 (UTF-16)    | 9 (UTF-16)  | 9 *(unchanged)*  |

This surfaces the concrete gate-flip: a boundary `ObjectMessage` whose `clientId`/keys push it just over the limit is **accepted by js** (UTF-16 undercount) but **rejected by cocoa/java** (UTF-8) — the same publish, two verdicts. Two distinct defects:

1. **Cross-SDK divergence.** js under-counted `clientId` and operation keys (UTF-16) while cocoa/java counted them in UTF-8 bytes.
2. **Intra-SDK inconsistency.** cocoa/java measured the *same* map key two different ways depending on whether it arrived via an operation (`MST3c`, UTF-8) or via map state (`OMP4a1`, UTF-16).

The authoritative definition already exists in Ably's published billing/limits accounting — **[How is maximum message size measured?](https://ably.com/docs/pricing/faqs)** — verbatim:

> The size is calculated as the sum of the `name`, `clientId`, `data` and `extras` properties before any compression or expansion occurs in the serialization process.
> - **name and clientId:** *"calculated as the size in bytes of their UTF-8 representation"*
> - **data:** *"calculated as the size in bytes if it is in binary, or its UTF-8 byte length if it is a string"*
> - **extras:** *"calculated as the string length of its JSON representation"*
> - binary on text transports: *"the size is calculated using the actual size of the binary data, not its base64 encoded string"*
> - arrays: *"the message size limit applies to the sum of all messages in the array"*

Note the deliberate asymmetry in the published contract: `name`/`clientId`/string `data` are **UTF-8 bytes**, but `extras` is **string length of its JSON representation**.

### Relationship to #331

This supersedes [#331](https://github.com/ably/specification/pull/331), the earlier attempt at the same disambiguation. **This work substantially agrees with #331** — its conclusions and these changes converge on the same unit for every field both cover (string `data`, `name`, `clientId`, `OD3e` → UTF-8), and per-point coverage is documented below. Two deltas:

- `extras` **deliberately follows the published docs** (UTF-16 string length) where #331's discussion had converged on UTF-8. Measuring `extras` in UTF-8 would over-count (`bytes ≥ units`) and **false-reject** documented-valid messages — the worse failure direction. #331's UTF-8-for-extras was a hedged consistency *preference* ("technically a bug ... not one that matters much"), with **no** authoritative server-side statement that the server byte-counts `extras`. The docs are the currently-published enforced contract.
- This PR additionally disambiguates the LiveObjects map/operation keys (`MCR3a1`/`MST3c`/`MRM3a`/`OMP4a1`) and `OD3g`, which #331 predates, and uses a single canonical umbrella at `TO3l8f` instead of per-type duplication (addressing #331's "don't copy-paste size clauses per type" review feedback).

#331 is now `CONFLICTING` (the repo migrated `textile/features.textile` → `specifications/features.md`, so its diff no longer applies). It is left open for the author to close; this PR notes the supersession.

## Solution

Match the service's published accounting **per field**. Every plain string and map key is measured in UTF-8 bytes; `extras` (and the regular-`Message` object/array `data` JSON) keep the documented "string length" (UTF-16 code units).

| Component | Spec point(s) | Unit | Rationale |
|-----------|---------------|------|-----------|
| `name` (regular Message) | TM6a + TO3l8f default | UTF-8 bytes | docs: "size in bytes of UTF-8 representation" |
| `clientId` (regular + object) | (TM6a) / OM3f | UTF-8 bytes | docs verbatim |
| string `data` | TM6f | UTF-8 bytes | docs verbatim |
| binary `data` / `bytes` | TM6c / OD3c | raw bytes | actual binary, not base64 |
| `ObjectData.string` | OD3e | UTF-8 bytes | same string family as values |
| `ObjectData.json` | OD3g | UTF-8 bytes | already byte-length; server counts bytes |
| `ObjectData.number` | OD3d | 8 | fixed |
| `ObjectData.boolean` | OD3b | 1 | fixed |
| operation keys | MCR3a1 / MST3c / MRM3a | UTF-8 bytes | keys are the same kind of string as values |
| map-state entry key | OMP4a1 | UTF-8 bytes | **changed from UTF-16** — consistency with operation keys |
| `extras` (regular + object) | TM6d / OM3d | **UTF-16 string length** of JSON | docs verbatim: "string length of its JSON representation" |
| object/array `data` (regular Message) | TM6b | **UTF-16 string length** after JSON-stringify | pre-existing convention; unchanged |

Per-clause edits to `specifications/features.md`:

- **→ UTF-8 byte length:** `TM6f` (string data), `OM3f` (object clientId), `MCR3a1`, `MST3c`, `MRM3a`, `OMP4a1` (all map/operation keys), `OD3e` (string), `OD3g` (json — clarified "byte" → "UTF-8 byte").
- **→ explicit UTF-16 string length:** `TM6b` (object/array data), `TM6d` and `OM3d` (extras) — reworded from bare "string length" to "string length (the number of UTF-16 code units)".
- **Canonical umbrella at `TO3l8f`:** one sentence establishing the default (all message-size string accounting is UTF-8 byte length unless a clause states otherwise, explicitly including the `json` `OD3g` payload) and enumerating the two UTF-16 exceptions (`extras` TM6d/OM3d and object/array `data` TM6b). Deliberately *one* umbrella rule rather than per-field/per-type duplication.

Wording-only change; no test additions in this repo.

## SDK status

| SDK | Sites | Fix | Status |
|-----|-------|-----|--------|
| **ably-js** | `objectmessage.ts` (clientId/OM3f, OMP4a1, MCR3a1, MST3c, MRM3a → `dataSizeBytes`); `message.ts` `getMessageSize` (name+clientId → `Utils.dataSizeBytes`) | UTF-8 for keys/clientId/name; `extras` stays `JSON.stringify(...).length` | companion PR: https://github.com/ably/ably-js/pull/2289 |
| **ably-cocoa** | `ObjectMessage.swift` `ObjectsMap.size` (OMP4a1: `utf16.count` → `utf8.count` — the one behavioural change); `ARTBaseMessage.m` core-Message alignment | UTF-8 keys; `extras`/object-array `data` UTF-16 | changes ready on `feature/liveobjects-implementation` |
| **ably-java** | `WireObjectMessage.kt` `WireObjectsMap.size` (OMP4a1: `.length` → `.byteSize`) | UTF-8 (java was the UTF-8 reference impl); `extras` UTF-16 | changes ready on `refactor/uts-objects-unit-into-liveobjects` |

## Notes

- **The `extras`/UTF-16 rationale.** The published accounting has an *explicit* rule for `extras` ("string length of its JSON representation") distinct from the byte rule for other strings. Matching it exactly (UTF-16 code units) makes the gate neither false-accept nor false-reject `extras` relative to the documented contract. UTF-8 would over-count and false-reject documented-valid messages. This is a deliberate documented exception, not an inconsistency; all three SDKs already agreed on UTF-16 here.
- **Why keys/strings are UTF-8 (strict-dominance).** For any string, `UTF-8 byte length ≥ UTF-16 code-unit count` (equality only for ASCII). Measuring a key in UTF-8 bytes *equals* the server's on-the-wire byte count, so the gate never false-accepts a key the server would reject. UTF-8 strictly dominates UTF-16 for keys.
- **`name`/`clientId` for regular `Message`** have no explicit per-field sub-clause in `TM6`; they are covered by the `TO3l8f` umbrella default (UTF-8).
- **`TP5` (PresenceMessage) needed no edit** — it already delegates wholesale to `TM6`, and `RSAN1a4` (annotations) delegates to `TO3l8`, so presence and annotation sizing inherit the rule with no separate edits.
